### PR TITLE
argparse -> OmegaConf and docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img  src="https://github.com/v-iashin/v-iashin.github.io/raw/master/images/video_features/vid_feats.gif" width="300" />
 </figure>
 
-`video_features` allows you to extract features from raw videos in parallel with multiple GPUs. 
+`video_features` allows you to extract features from raw videos in parallel with multiple GPUs.
 It supports several extractors that capture visual appearance, optical flow, and audio features.
 See more details in [Documentation](https://v-iashin.github.io/video_features/).
 
@@ -19,11 +19,10 @@ conda activate torch_zoo
 
 # extract r(2+1)d features for the sample videos
 python main.py \
-    --feature_type r21d_rgb \
-    --device_ids 0 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=r21d \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 
-# use `--device_ids 0 2` to run on 0th and 2nd devices in parallel
+# use `device_ids="[0, 2]"` to run on 0th and 2nd devices in parallel
 ```
 
 ## Supported models
@@ -39,7 +38,7 @@ Sound Recognition
 
 Optical Flow
 
-- [RAFT (FlyingChairs, FlyingThings3D, Sintel)](https://v-iashin.github.io/video_features/models/raft)
+- [RAFT (FlyingChairs, FlyingThings3D, Sintel, KITTI)](https://v-iashin.github.io/video_features/models/raft)
 - [PWC-Net (Sintel)](https://v-iashin.github.io/video_features/models/pwc)
 
 Image Recognition
@@ -49,14 +48,14 @@ Image Recognition
 ## Used for
 
 * [SpecVQGAN](https://arxiv.org/abs/2110.08791) branch `specvqgan`
-* [BMT](https://arxiv.org/abs/2005.08271) branch `bmt` 
+* [BMT](https://arxiv.org/abs/2005.08271) branch `bmt`
 * [MDVC](https://arxiv.org/abs/2003.07758) branch `mdvc`
 
 Please, let me know if you found this repo useful for your projects or papers.
 
 ## Ideas for Contributions
 
-I would be happy to consider your ideas and PRs. 
+I would be happy to consider your ideas and PRs.
 Here is a few things I have in mind:
 
 - [ ] PyTorch DDP support (for multi-node extraction)

--- a/README.md
+++ b/README.md
@@ -60,5 +60,4 @@ Here is a few things I have in mind:
 
 - [ ] PyTorch DDP support (for multi-node extraction)
 - [ ] Refactor the code base with OOP in mind – now the code is a bit redundant for each feature
-- [ ] Config support (e.g. with `OmegaConf`)
 - [ ] More models, of course

--- a/conda_env_pwc.yml
+++ b/conda_env_pwc.yml
@@ -5,12 +5,13 @@ channels:
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
+  - antlr-python-runtime=4.9.3=pyhd8ed1ab_1
   - autopep8=1.4.4=py_0
   - av=7.0.1=py37hfbe2fac_1
   - blas=1.0=mkl
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.7.22=0
-  - certifi=2020.6.20=py37_0
+  - ca-certificates=2021.10.8=ha878542_0
+  - certifi=2021.10.8=py37h89c1867_1
   - cffi=1.14.0=py37he30daa8_1
   - cudatoolkit=10.0.130=0
   - cudnn=7.3.1=cuda10.0_0
@@ -48,8 +49,9 @@ dependencies:
   - numpy=1.15.4=py37h7e9f1db_0
   - numpy-base=1.15.4=py37hde5b4d6_0
   - olefile=0.46=py37_0
+  - omegaconf=2.1.1=py37h89c1867_1
   - openh264=1.8.0=hd408876_0
-  - openssl=1.1.1h=h7b6447c_0
+  - openssl=1.1.1l=h7f8727e_0
   - pillow=6.1.0=py37h34e0f95_0
   - pip=20.0.2=py37_3
   - pycodestyle=2.6.0=py_0
@@ -58,6 +60,7 @@ dependencies:
   - python=3.7.7=hcff3b4d_5
   - python_abi=3.7=1_cp37m
   - pytorch=1.2.0=py3.7_cuda10.0.130_cudnn7.6.2_0
+  - pyyaml=5.3.1=py37hb5d75c8_1
   - readline=8.0=h7b6447c_0
   - rope=0.17.0=py_0
   - scipy=1.5.2=py37h0b6359f_0
@@ -67,9 +70,11 @@ dependencies:
   - tk=8.6.8=hbc83047_0
   - torchvision=0.4.0=py37_cu100
   - tqdm=4.46.0=py_0
+  - typing_extensions=4.0.1=pyha770c72_0
   - wheel=0.34.2=py37_0
   - x264=1!152.20180806=h7b6447c_0
   - xz=5.2.5=h7b6447c_0
+  - yaml=0.2.5=h516909a_0
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0

--- a/conda_env_torch_zoo.yml
+++ b/conda_env_torch_zoo.yml
@@ -5,6 +5,7 @@ channels:
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
+  - antlr-python-runtime=4.9.3=pyhd8ed1ab_1
   - av=8.0.2=py38he20a9df_1
   - blas=1.0=mkl
   - bzip2=1.0.8=h516909a_3
@@ -48,6 +49,7 @@ dependencies:
   - numpy=1.19.1=py38hbc911f0_0
   - numpy-base=1.19.1=py38hfa32c7d_0
   - olefile=0.46=py_0
+  - omegaconf=2.1.1=py38h578d9bd_1
   - openh264=2.1.1=h8b12597_0
   - openssl=1.1.1h=h516909a_0
   - pillow=7.2.0=py38hb39fc2d_0
@@ -57,6 +59,7 @@ dependencies:
   - python=3.8.5=h7579374_1
   - python_abi=3.8=1_cp38
   - pytorch=1.6.0=py3.8_cuda10.2.89_cudnn7.6.5_0
+  - pyyaml=5.3.1=py38h8df0ef7_1
   - readline=8.0=h7b6447c_0
   - resampy=0.2.2=py_0
   - scipy=1.5.2=py38h0b6359f_0
@@ -67,9 +70,11 @@ dependencies:
   - tk=8.6.10=hbc83047_0
   - torchvision=0.7.0=py38_cu102
   - tqdm=4.49.0=py_0
+  - typing_extensions=4.0.1=pyha770c72_0
   - wheel=0.35.1=py_0
   - x264=1!152.20180806=h14c3975_0
   - xz=5.2.5=h7b6447c_0
+  - yaml=0.2.5=h516909a_0
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.4.5=h9ceee32_0
   - pip:

--- a/configs/i3d.yml
+++ b/configs/i3d.yml
@@ -1,0 +1,21 @@
+# Model
+feature_type: 'i3d'
+stack_size: 64 # Feature time span in fps
+step_size: 64 # Feature step size in fps
+streams: null # Streams to use for feature extraction. Both used if left as "null" (None)
+flow_type: 'pwc' # Flow to use in I3D. 'pwc' (PWCNet) is faster while 'raft' (RAFT) is more accurate.
+extraction_fps: null # For original video fps, leave as "null" (None)
+
+# Extraction Parameters
+device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
+output_path: './output' # where to store results if saved
+tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)
+keep_tmp_files: false # to keep temp files after feature extraction.
+show_pred: false # to show preds of a model, i.e. on a pre-train dataset for each feature (Kinetics 400)
+
+# config
+config: null
+
+# Video paths
+file_with_video_paths: null # if the list of videos is large, you might put them in a txt file, use this argument to specify the path

--- a/configs/pwc.yml
+++ b/configs/pwc.yml
@@ -1,8 +1,8 @@
 # Model
 feature_type: 'pwc'
 extraction_fps: null # For original video fps, leave unspecified as "null" (None)
-side_size: null # resize the frame resolution: min(W, H) = side_size, e.g. 256
-resize_to_smaller_edge: true # if side_size is not "null", the *smaller* side in (H, W) will be resized to the `side_size`
+side_size: null # if resized to the smaller edge, min(W, H) = side_size, if to the larger: max(W, H), if "null" (None) no resize is performed
+resize_to_smaller_edge: true # if false, the larger edge will be used to be resized to `side_size`
 
 # Extraction Parameters
 batch_size: 1 # increase the extraction speed with batching

--- a/configs/pwc.yml
+++ b/configs/pwc.yml
@@ -1,0 +1,20 @@
+# Model
+feature_type: 'pwc'
+extraction_fps: null # For original video fps, leave unspecified as "null" (None)
+side_size: null # resize the frame resolution: min(W, H) = side_size, e.g. 256
+resize_to_smaller_edge: true # if side_size is not "null", the *smaller* side in (H, W) will be resized to the `side_size`
+
+# Extraction Parameters
+batch_size: 1 # increase the extraction speed with batching
+device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
+output_path: './output' # where to store results if saved
+tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)
+keep_tmp_files: false # to keep temp files after feature extraction.
+show_pred: false # to show preds of a model, i.e. on a pre-train dataset for each feature (Kinetics 400)
+
+# config
+config: null
+
+# Video paths
+file_with_video_paths: null # if the list of videos is large, you might put them in a txt file, use this argument to specify the path

--- a/configs/r21d.yml
+++ b/configs/r21d.yml
@@ -1,0 +1,19 @@
+# Model
+feature_type: 'r21d'
+stack_size: 16 # Feature time span in fps
+step_size: 16 # Feature step size in fps
+extraction_fps: null # For original video fps, leave unspecified "null" (None)
+
+# Extraction Parameters
+device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
+output_path: './output' # where to store results if saved
+tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)
+keep_tmp_files: false # to keep temp files after feature extraction.
+show_pred: false # to show preds of a model, i.e. on a pre-train dataset for each feature (Kinetics 400)
+
+# config
+config: null
+
+# Video paths
+file_with_video_paths: null # if the list of videos is large, you might put them in a txt file, use this argument to specify the path

--- a/configs/raft.yml
+++ b/configs/raft.yml
@@ -1,0 +1,20 @@
+# Model
+feature_type: 'pwc'
+extraction_fps: null # For original video fps, leave as "null" (None)
+side_size: null # resize the frame resolution: max(W, H) = side_size, if "null" (None) no resize is performed
+resize_to_larger_edge: true # if side_size is specified, the *larger* side in (H, W) will be resized to the `side_size`
+
+# Extraction Parameters
+batch_size: 1 # increase the extraction speed with batching
+device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
+output_path: './output' # where to store results if saved
+tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)
+keep_tmp_files: false # to keep temp files after feature extraction.
+show_pred: false # to show preds of a model, i.e. on a pre-train dataset for each feature (Kinetics 400)
+
+# config
+config: null
+
+# Video paths
+file_with_video_paths: null # if the list of videos is large, you might put them in a txt file, use this argument to specify the path

--- a/configs/raft.yml
+++ b/configs/raft.yml
@@ -1,8 +1,9 @@
 # Model
 feature_type: 'pwc'
 extraction_fps: null # For original video fps, leave as "null" (None)
-side_size: null # resize the frame resolution: max(W, H) = side_size, if "null" (None) no resize is performed
-resize_to_larger_edge: true # if side_size is specified, the *larger* side in (H, W) will be resized to the `side_size`
+side_size: null # if resized to the smaller edge, min(W, H) = side_size, if to the larger: max(W, H), if "null" (None) no resize is performed
+resize_to_smaller_edge: true # if false, the larger edge will be used to be resized to `side_size`
+finetuned_on: 'sintel' # also 'kitti' is supported
 
 # Extraction Parameters
 batch_size: 1 # increase the extraction speed with batching

--- a/configs/resnet.yml
+++ b/configs/resnet.yml
@@ -1,0 +1,17 @@
+# Model
+feature_type: 'resnet50'
+batch_size: 1 # Batchsize (only frame-wise extractors are supported)
+
+# Extraction Parameters
+device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
+output_path: './output' # where to store results if saved
+tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)
+keep_tmp_files: false # to keep temp files after feature extraction.
+show_pred: false # to show preds of a model, i.e. on a pre-train dataset for each feature (Kinetics 400)
+
+# config
+config: null
+
+# Video paths
+file_with_video_paths: null # if the list of videos is large, you might put them in a txt file, use this argument to specify the path

--- a/configs/resnet.yml
+++ b/configs/resnet.yml
@@ -1,6 +1,7 @@
 # Model
 feature_type: 'resnet50'
 batch_size: 1 # Batchsize (only frame-wise extractors are supported)
+extraction_fps: null # For original video fps, leave unspecified "null" (None)
 
 # Extraction Parameters
 device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.

--- a/configs/vggish.yml
+++ b/configs/vggish.yml
@@ -1,0 +1,16 @@
+# Model
+feature_type: 'vggish'
+
+# Extraction Parameters
+device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
+output_path: './output' # where to store results if saved
+tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)
+keep_tmp_files: false # to keep temp files after feature extraction.
+show_pred: false # to show preds of a model, i.e. on a pre-train dataset for each feature (Kinetics 400)
+
+# config
+config: null
+
+# Video paths
+file_with_video_paths: null # if the list of videos is large, you might put them in a txt file, use this argument to specify the path

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
   <img src="_assets/base.png" width="300" />
 </figure>
 
-`video_features` allows you to extract features from raw videos in parallel with multiple GPUs. 
+`video_features` allows you to extract features from raw videos in parallel with multiple GPUs.
 It supports several extractors that capture visual appearance, optical flow, and audio features.
 
 Action Recognition

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Sound Recognition
 
 Optical Flow
 
-- [RAFT (FlyingChairs, FlyingThings3D, Sintel)](https://v-iashin.github.io/video_features/models/raft)
+- [RAFT (FlyingChairs, FlyingThings3D, Sintel, KITTI)](https://v-iashin.github.io/video_features/models/raft)
 - [PWC-Net (Sintel)](https://v-iashin.github.io/video_features/models/pwc/)
 
 

--- a/docs/models/i3d.md
+++ b/docs/models/i3d.md
@@ -74,7 +74,8 @@ You can change the output folder using `--output_path` argument.
 Also, you may want to try to change I3D window and step sizes
 ```bash
 python main.py \
-    --feature_type i3d --device_ids 0 2 \
+    --feature_type i3d \
+    --device_ids 0 2 \
     --stack_size 24 \
     --step_size 24 \
     --file_with_video_paths ./sample/sample_video_paths.txt

--- a/docs/models/i3d.md
+++ b/docs/models/i3d.md
@@ -13,16 +13,31 @@ Please note, this implementation uses either [PWC-Net](https://arxiv.org/abs/170
 Depending on whether you would like to use PWC-Net or RAFT for optical flow extraction, you will need to install separate conda environments – `conda_env_pwc.yml` and `conda_env_torch_zoo`, respectively
 
 ```bash
-# it will create a new conda environment called 'pwc' (or/and `torch_zoo`) on your machine
+# it will create a new conda environment called 'pwc' on your machine
 conda env create -f conda_env_pwc.yml
-# or/and
+# or/and if you would like to extract optical flow with RAFT
 conda env create -f conda_env_torch_zoo.yml
 ```
 
 ---
 
+## Minimal Working Example
+
+```bash
+# Activate the environment
+conda activate pwc
+# if you would like to use RAFT as optical flow extractor use:
+# conda activate torch_zoo
+
+# extract features from "./sample/v_ZNVhz7ctTq0.mp4" video and show the predicted classes
+python main.py \
+    feature_type=i3d \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4]" \
+    show_pred=true
+```
+
 ## Examples
-Start by activating the environment
+Activate the environment
 ```bash
 conda activate pwc
 ```
@@ -30,66 +45,67 @@ conda activate pwc
 The following will extract I3D features for sample videos using 0th and 2nd devices in parallel. The features are going to be extracted with the default parameters.
 ```bash
 python main.py \
-    --feature_type i3d \
-    --device_ids 0 2 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=i3d \
+    device_ids="[0, 2]" \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
 The video paths can be specified as a `.txt` file with paths
 ```bash
 python main.py \
-    --feature_type i3d \
-    --device_ids 0 2 \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=i3d \
+    device_ids="[0, 2]" \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 It is also possible to extract features from either `rgb` or `flow` modalities individually (`--streams`) and, therefore, increasing the speed
 ```bash
 python main.py \
-    --feature_type i3d \
-    --streams flow \
-    --device_ids 0 2 \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=i3d \
+    streams=flow \
+    device_ids="[0, 2]" \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 
 To extract optical flow frames using RAFT approach, specify `--flow_type raft`. Note that using RAFT will make the extraction slower than with PWC-Net yet visual inspection of extracted flow frames suggests that RAFT has a better quality of the estimated flow
 ```bash
 # make sure to activate the correct environment (`torch_zoo`)
+# conda activate torch_zoo
 python main.py \
-    --feature_type i3d \
-    --flow_type raft \
-    --device_ids 0 2 \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=i3d \
+    flow_type=raft \
+    device_ids="[0, 2]" \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 
 The features can be saved as numpy arrays by specifying `--on_extraction save_numpy` or `save_pickle`. By default, it will create a folder `./output` and will store features there
 ```bash
 python main.py \
-    --feature_type i3d \
-    --device_ids 0 2 \
-    --on_extraction save_numpy \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=i3d \
+    device_ids="[0, 2]" \
+    on_extraction=save_pickle \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 You can change the output folder using `--output_path` argument.
 
 Also, you may want to try to change I3D window and step sizes
 ```bash
 python main.py \
-    --feature_type i3d \
-    --device_ids 0 2 \
-    --stack_size 24 \
-    --step_size 24 \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=i3d \
+    device_ids="[0, 2]" \
+    stack_size=24 \
+    step_size=24 \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 
 By default, the frames are extracted according to the original fps of a video. If you would like to extract frames at a certain fps, specify `--extraction_fps` argument.
 ```bash
 python main.py \
-    --feature_type i3d \
-    --device_ids 0 2 \
-    --extraction_fps 25 \
-    --stack_size 24 \
-    --step_size 24 \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=i3d \
+    device_ids="[0, 2]" \
+    extraction_fps=25 \
+    stack_size=24 \
+    step_size=24 \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 A fun note, the time span of the I3D features in the last example will match the time span of VGGish features with default parameters (24/25 = 0.96).
 

--- a/docs/models/i3d.md
+++ b/docs/models/i3d.md
@@ -36,6 +36,8 @@ python main.py \
     show_pred=true
 ```
 
+---
+
 ## Examples
 Activate the environment
 ```bash
@@ -82,7 +84,7 @@ The features can be saved as numpy arrays by specifying `--on_extraction save_nu
 python main.py \
     feature_type=i3d \
     device_ids="[0, 2]" \
-    on_extraction=save_pickle \
+    on_extraction=save_numpy \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
 You can change the output folder using `--output_path` argument.

--- a/docs/models/r21d.md
+++ b/docs/models/r21d.md
@@ -17,6 +17,21 @@ conda env create -f conda_env_torch_zoo.yml
 
 ---
 
+## Minimal Working Example
+
+```bash
+# Activate the environment
+conda activate torch_zoo
+
+# extract features from "./sample/v_GGSY1Qvo990.mp4" video and show the predicted classes
+python main.py \
+    feature_type=r21d \
+    video_paths="[./sample/v_GGSY1Qvo990.mp4]" \
+    show_pred=true
+```
+
+---
+
 ## Example
 Start by activating the environment
 ```bash
@@ -26,11 +41,11 @@ conda activate torch_zoo
 It will extract R(2+1)d features for sample videos using 0th and 2nd devices in parallel. The features are going to be extracted with the default parameters.
 ```bash
 python main.py \
-    --feature_type r21d_rgb \
-    --device_ids 0 2 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=r21d \
+    device_ids="[0, 2]" \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
-See [I3D Examples](i3d.md). Note, that R(2+1)d only supports RGB stream.
+See [I3D Examples](i3d.md). Note, that this implementation of R(2+1)d only supports the RGB stream.
 
 ---
 

--- a/docs/models/raft.md
+++ b/docs/models/raft.md
@@ -3,7 +3,14 @@
   <img src="../../_assets/raft.png" width="300" />
 </figure>
 
-[Recurrent All-Pairs Field Transforms for Optical Flow (RAFT)](https://arxiv.org/abs/2003.12039) frames are extracted for every consecutive pair of frames in a video. The implementation follows the [official implementation](https://github.com/princeton-vl/RAFT/tree/25eb2ac723c36865c636c9d1f497af8023981868). RAFT is pre-trained on [FlyingChairs](https://lmb.informatik.uni-freiburg.de/resources/datasets/FlyingChairs.en.html), fine-tuned on [FlyingThings3D](https://lmb.informatik.uni-freiburg.de/resources/datasets/SceneFlowDatasets.en.html), then it is finetuned on [Sintel](http://sintel.is.tue.mpg.de/) or [KITTI-2015](http://www.cvlibs.net/datasets/kitti/eval_scene_flow.php?benchmark=flow) (see the Training Schedule in the Experiments section in the RAFT paper). By default, the frames are extracted using the Sintel model – you may change this behavior in `./models/raft/extract_raft.py`. Also, check out  and [this issue](https://github.com/princeton-vl/RAFT/issues/37) to learn more about the shared models.
+[Recurrent All-Pairs Field Transforms for Optical Flow (RAFT)](https://arxiv.org/abs/2003.12039) frames are extracted for every
+consecutive pair of frames in a video.
+The implementation follows the [official implementation](https://github.com/princeton-vl/RAFT/tree/25eb2ac723c36865c636c9d1f497af8023981868).
+RAFT is pre-trained on [FlyingChairs](https://lmb.informatik.uni-freiburg.de/resources/datasets/FlyingChairs.en.html),
+fine-tuned on [FlyingThings3D](https://lmb.informatik.uni-freiburg.de/resources/datasets/SceneFlowDatasets.en.html), then it is finetuned
+on [Sintel](http://sintel.is.tue.mpg.de/) or [KITTI-2015](http://www.cvlibs.net/datasets/kitti/eval_scene_flow.php?benchmark=flow)
+(see the Training Schedule in the Experiments section in the RAFT paper).
+Also, check out and [this issue](https://github.com/princeton-vl/RAFT/issues/37) to learn more about the shared models.
 
 The optical flow frames have the same size as the video input or as specified by the resize arguments. We additionally output timesteps in ms for each feature and fps of the video.
 
@@ -18,7 +25,26 @@ conda env create -f conda_env_torch_zoo.yml
 
 ---
 
+## Minimal Working Example
+
+```bash
+# Activate the environment
+conda activate torch_zoo
+
+# extract optical flow from "./sample/v_GGSY1Qvo990.mp4" using one GPU and show the flow for each frame
+python main.py \
+    feature_type=raft \
+    show_pred=true \
+    video_paths="[./sample/v_GGSY1Qvo990.mp4]"
+
+# if `show_pred=true`, the window with predictions will appear, use any key to show the next frame.
+# To use `show_pred=true`, a screen must be attached to the machine or X11 forwarding is enabled.
+```
+
+---
+
 ## Examples
+
 Start by activating the environment
 ```bash
 conda activate torch_zoo
@@ -28,53 +54,56 @@ A minimal working example:
 it will extract RAFT optical flow frames for sample videos using 0th and 2nd devices in parallel.
 ```bash
 python main.py \
-    --feature_type raft \
-    --device_ids 0 2 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=raft \
+    device_ids="[0, 2]" \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 Note, if your videos are quite long, have large dimensions and fps, watch your RAM as the frames are stored in the memory until they are saved. Please see other examples how can you overcome this problem.
+
+By default, the frames are extracted using the Sintel model. If you wish you can use KITTI-pretrained model by changing the `finetuned_on` argument:
+```bash
+python main.py \
+    feature_type=raft \
+    device_ids="[0, 2]" \
+    finetuned_on=kitti \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
+```
 
 If you would like to save the frames, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the frames are saved in `./output/` or where `--output_path` specifies. In the case of RAFT, besides frames, it also saves timestamps in ms and the original fps of the video into the same folder with features.
 ```bash
 python main.py \
-    --feature_type raft \
-    --device_ids 0 2 \
-    --on_extraction save_numpy \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=raft \
+    device_ids="[0, 2]" \
+    on_extraction=save_numpy \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 Since extracting flow between two frames is cheap we may increase the extraction speed with batching. Therefore, you can use `--batch_size` argument (defaults to `1`) to do so. _A precaution: make sure to properly test the memory impact of using a specific batch size if you are not sure which kind of videos you have. For instance, you tested the extraction on 16:9 aspect ratio videos but some videos are 16:10 which might give you a mem error. Therefore, I would recommend to tune `--batch_size` on a square video and using the resize arguments (showed later)_
 ```bash
 python main.py \
-    --feature_type raft \
-    --device_ids 0 2 \
-    --batch_size 16 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=raft \
+    device_ids="[0, 2]" \
+    batch_size=16 \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
-Another way of speeding up the extraction is to resize the input frames. Use `--side_size` to specify the target size of the smallest side (such that `min(W, H) = side_size`) or of the largest side if `--resize_to_larger_edge` is used (such that `max(W, H) = side_size`). The latter might be useful when you are not sure which aspect ratio the videos have.
+Another way of speeding up the extraction is to resize the input frames.
+Use `resize_to_smaller_edge=true` (default) if you would like `--side_size` to be `min(W, H)`
+if `resize_to_smaller_edge=false` the `--side_size` value will correspond to be `max(W, H)` .
+The latter might be useful when you are not sure which aspect ratio the videos have (the upper bound on size).
 ```bash
 python main.py \
-    --feature_type raft \
-    --device_ids 0 2 \
-    --side_size 256 \
-    --resize_to_larger_edge \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=raft \
+    device_ids="[0, 2]" \
+    side_size=256 \
+    resize_to_smaller_edge=false \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 If the videos have different fps rate, `--extraction_fps` might be used to specify the target fps of all videos (a video is reencoded and saved to `--tmp_path` folder and deleted if `--keep_tmp_files` wasn't used).
 ```bash
 python main.py \
-    --feature_type raft \
-    --device_ids 0 2 \
-    --extraction_fps 1 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
-```
-Finally, if you would like to test, if the extracted optical flow frames are meaningful or to debug the extraction, use `--show_pred` – it will show the original frame of a video along with the extracted optical flow. (when the window will pop up, use your favorite keys on a keyboard to show the next frame)
-```bash
-python main.py \
-    --feature_type raft \
-    --device_ids 0 \
-    --show_pred \
-    --extraction_fps 5 \
-    --video_paths ./sample/v_GGSY1Qvo990.mp4
+    feature_type=raft \
+    device_ids="[0, 2]" \
+    extraction_fps=1 \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
 ---

--- a/docs/models/resnet.md
+++ b/docs/models/resnet.md
@@ -22,6 +22,22 @@ conda env create -f conda_env_torch_zoo.yml
 
 ---
 
+## Minimal Working Example
+
+```bash
+# Activate the environment
+conda activate torch_zoo
+
+# extract features from "./sample/v_GGSY1Qvo990.mp4" video and show the predicted classes
+python main.py \
+    feature_type=resnet101 \
+    video_paths="[./sample/v_GGSY1Qvo990.mp4]" \
+    extraction_fps=1 \
+    show_pred=true
+```
+
+---
+
 ## Examples
 Start by activating the environment
 ```bash
@@ -31,33 +47,33 @@ conda activate torch_zoo
 It is pretty much the same procedure as with other features. The example is provided for the ResNet-50 flavour, but we also support ResNet-18,34,101,152.
 ```bash
 python main.py \
-    --feature_type resnet50 \
-    --device_ids 0 2 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=resnet50 \
+    device_ids="[0, 2]" \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 If you would like to save the features, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the features are saved in `./output/` or where `--output_path` specifies. In the case of frame-wise features, besides features, it also saves timestamps in ms and the original fps of the video into the same folder with features.
 ```bash
 python main.py \
-    --feature_type resnet50 \
-    --device_ids 0 2 \
-    --on_extraction save_numpy \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=resnet50 \
+    device_ids="[0, 2]" \
+    on_extraction=save_numpy \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 Since these features are so fine-grained and light-weight we may increase the extraction speed with batching. Therefore, frame-wise features have `--batch_size` argument, which defaults to `1`.
 ```bash
 python main.py \
-    --feature_type resnet50 \
-    --device_ids 0 2 \
-    --batch_size 128 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=resnet50 \
+    device_ids="[0, 2]" \
+    batch_size=128 \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 If you would like to extract features at a certain fps, add `--extraction_fps` argument
 ```bash
 python main.py \
-    --feature_type resnet50 \
-    --device_ids 0 2 \
-    --extraction_fps 5 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
+    feature_type=resnet50 \
+    device_ids="[0, 2]" \
+    extraction_fps=5 \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
 ---

--- a/docs/models/vggish.md
+++ b/docs/models/vggish.md
@@ -17,34 +17,39 @@ Setup `conda` environment. Requirements are in file `conda_env_torch_zoo.yml`
 ```bash
 # it will create a new conda environment called 'torch_zoo' on your machine
 conda env create -f conda_env_torch_zoo.yml
-conda activate torch_zoo
 ```
 
 ---
 
+## Minimal Working Example
+
+```bash
+# Activate the environment
+conda activate torch_zoo
+
+# extract features from "./sample/v_GGSY1Qvo990.mp4" video
+python main.py \
+    feature_type=vggish \
+    video_paths="[./sample/v_GGSY1Qvo990.mp4]"
+```
+---
+
 ## Example
 
+The video paths can be specified as a `.txt` file with paths.
 ```bash
 python main.py \
-    --feature_type vggish \
-    --device_ids 0 2 \
-    --video_paths ./sample/v_ZNVhz7ctTq0.mp4 ./sample/v_GGSY1Qvo990.mp4
-```
-
-The video paths can be specified as a `.txt` file with paths
-```bash
-python main.py \
-    --feature_type vggish \
-    --device_ids 0 2 \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=vggish \
+    device_ids="[0, 2]" \
+    file_with_video_paths=./sample/sample_video_paths.txt
 ```
 The features can be saved as numpy arrays by specifying `--on_extraction save_numpy` or `save_pickle`. By default, it will create a folder `./output` and will store features there (you can change the output folder using `--output_path`)
 ```bash
 python main.py \
-    --feature_type vggish \
-    --device_ids 0 2 \
-    --on_extraction save_numpy \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+    feature_type=vggish \
+    device_ids="[0, 2]" \
+    on_extraction=save_numpy \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
 ---
@@ -52,11 +57,10 @@ python main.py \
 ## Difference between Tensorflow and PyTorch implementations
 
 ```
-python main.py \               
-    --feature_type vggish \
-    --device_ids 0 1 \
-    --on_extraction save_numpy \
-    --file_with_video_paths ./sample/sample_video_paths.txt
+python main.py \
+    feature_type=vggish \
+    on_extraction=save_numpy \
+    file_with_video_paths=./sample/sample_video_paths.txt
 
 TF (./sample/v_GGSY1Qvo990.mp4):
 [[0.         0.04247099 0.09079538 ... 0.         0.18485409 0.        ]

--- a/main.py
+++ b/main.py
@@ -4,9 +4,9 @@
 # (see https://github.com/pytorch/pytorch/issues/37377)
 import numpy
 import torch
-import argparse
+from omegaconf import OmegaConf
 
-from utils.utils import form_list_from_user_input, sanity_check
+from utils.utils import build_cfg_path, form_list_from_user_input, sanity_check
 
 def parallel_feature_extraction(args):
     '''Distributes the feature extraction in embarasingly-parallel fashion. Specifically,
@@ -49,47 +49,18 @@ def parallel_feature_extraction(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Extract Features')
-    parser.add_argument('--feature_type', required=True,
-                        choices=['i3d', 'vggish', 'r21d_rgb', 'resnet18', 'resnet34', 'resnet50', 'resnet101',
-                                 'resnet152', 'raft', 'pwc'])
-    parser.add_argument('--video_paths', nargs='+', help='space-separated paths to videos')
-    parser.add_argument('--file_with_video_paths', help='.txt file where each line is a path')
-    parser.add_argument('--device_ids', type=int, nargs='+', help='space-separated device ids')
-    parser.add_argument('--tmp_path', default='./tmp',
-                        help='folder to store the temporary files used for extraction (frames or aud files)')
-    parser.add_argument('--keep_tmp_files', dest='keep_tmp_files', action='store_true', default=False,
-                        help='to keep temp files after feature extraction. (works only for vggish and i3d)')
-    parser.add_argument('--on_extraction', default='print', choices=['print', 'save_numpy', 'save_pickle'],
-                        help='what to do once the stack is extracted')
-    parser.add_argument('--output_path', default='./output', help='where to store results if saved')
-
-    parser.add_argument('--extraction_fps', type=float, help='For original video fps, leave unspecified')
-    parser.add_argument('--stack_size', type=int, help='Feature time span in fps')
-    parser.add_argument('--step_size', type=int, help='Feature step size in fps')
-    parser.add_argument('--streams', nargs='+', choices=['flow', 'rgb'],
-                        help='Streams to use for feature extraction. Both used if not specified')
-    parser.add_argument('--flow_type', choices=['raft', 'pwc'], default='pwc',
-                        help='Flow to use in I3D. PWC is faster while RAFT is more accurate.')
-    parser.add_argument('--batch_size', type=int, default=1,
-                        help='Batchsize (only frame-wise extractors are supported)')
-    parser.add_argument('--resize_to_larger_edge', dest='resize_to_smaller_edge', action='store_false',
-                        default=True, help='The larger side will be resized to this number maintaining the'
-                        + 'aspect ratio. By default, uses the smaller side (as Resize in torchvision).')
-    parser.add_argument('--side_size', type=int,
-                        help='If specified, the input images will be resized to this value in RAFT.')
-    parser.add_argument(
-        '--show_pred', dest='show_pred', action='store_true', default=False,
-        help='to show preds of a model, i.e. on a pre-train dataset (imagenet or kinetics) for each feature'
-    )
-
-    args = parser.parse_args()
-
+    cfg_cli = OmegaConf.from_cli()
+    print(cfg_cli)
+    cfg_yml = OmegaConf.load(build_cfg_path(cfg_cli.feature_type))
+    # the latter arguments are prioritized
+    cfg = OmegaConf.merge(cfg_yml, cfg_cli)
+    OmegaConf.set_readonly(cfg, True)
+    print(OmegaConf.to_yaml(cfg))
     # some printing
-    if args.on_extraction in ['save_numpy', 'save_pickle']:
-        print(f'Saving features to {args.output_path}')
-    if args.keep_tmp_files:
-        print(f'Keeping temp files in {args.tmp_path}')
+    if cfg.on_extraction in ['save_numpy', 'save_pickle']:
+        print(f'Saving features to {cfg.output_path}')
+    if cfg.keep_tmp_files:
+        print(f'Keeping temp files in {cfg.tmp_path}')
 
-    sanity_check(args)
-    parallel_feature_extraction(args)
+    sanity_check(cfg)
+    parallel_feature_extraction(cfg)

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def parallel_feature_extraction(args):
     if args.feature_type == 'i3d':
         from models.i3d.extract_i3d import ExtractI3D  # defined here to avoid import errors
         extractor = ExtractI3D(args)
-    elif args.feature_type == 'r21d_rgb':
+    elif args.feature_type == 'r21d':
         from models.r21d.extract_r21d import ExtractR21D  # defined here to avoid import errors
         extractor = ExtractR21D(args)
     elif args.feature_type == 'vggish':

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     cfg_yml = OmegaConf.load(build_cfg_path(cfg_cli.feature_type))
     # the latter arguments are prioritized
     cfg = OmegaConf.merge(cfg_yml, cfg_cli)
-    OmegaConf.set_readonly(cfg, True)
+    # OmegaConf.set_readonly(cfg, True)
     print(OmegaConf.to_yaml(cfg))
     # some printing
     if cfg.on_extraction in ['save_numpy', 'save_pickle']:

--- a/models/i3d/extract_i3d.py
+++ b/models/i3d/extract_i3d.py
@@ -36,7 +36,7 @@ class ExtractI3D(torch.nn.Module):
         if args.streams is None:
             self.streams = ['rgb', 'flow']
         else:
-            self.streams = args.streams
+            self.streams = [args.streams]
         self.path_list = form_list_from_user_input(args)
         self.flow_type = args.flow_type
         self.flow_model_paths = {'pwc': PWC_MODEL_PATH, 'raft': RAFT_MODEL_PATH}

--- a/models/pwc/extract_pwc.py
+++ b/models/pwc/extract_pwc.py
@@ -155,14 +155,14 @@ class ExtractPWC(torch.nn.Module):
 
         return features_with_meta
 
-    def show_flow_for_every_pair_of_frames(self, flow_up: torch.Tensor, batch: torch.Tensor):
+    def show_flow_for_every_pair_of_frames(self, out: torch.Tensor, batch: torch.Tensor):
         '''Shows the resulting flow as well as the first frame
 
         Args:
-            flow_up (torch.Tensor): the output of the RAFT
+            out (torch.Tensor): the output of the model
             batch (torch.Tensor): the stack of rgb inputs
         '''
-        for idx, flow in enumerate(flow_up):
+        for idx, flow in enumerate(out):
             img = batch[idx].permute(1, 2, 0).cpu().numpy()
             flow = flow.permute(1, 2, 0).cpu().numpy()
             flow = flow_viz.flow_to_image(flow)

--- a/models/raft/extract_raft.py
+++ b/models/raft/extract_raft.py
@@ -14,8 +14,10 @@ from tqdm import tqdm
 from utils.utils import (action_on_extraction, form_list_from_user_input,
                          reencode_video_with_diff_fps)
 
-# RAFT_MODEL_PATH = './models/raft/checkpoints/raft-kitti.pth'
-RAFT_MODEL_PATH = './models/raft/checkpoints/raft-sintel.pth'
+RAFT_MODEL_PATH = {
+    'sintel': './models/raft/checkpoints/raft-sintel.pth',
+    'kitti': './models/raft/checkpoints/raft-kitti.pth',
+}
 
 class ExtractRAFT(torch.nn.Module):
 
@@ -23,7 +25,7 @@ class ExtractRAFT(torch.nn.Module):
         super(ExtractRAFT, self).__init__()
         self.feature_type = args.feature_type
         self.path_list = form_list_from_user_input(args)
-        self.model_path = RAFT_MODEL_PATH
+        self.model_path = RAFT_MODEL_PATH[args.finetuned_on]
         self.batch_size = args.batch_size
         self.extraction_fps = args.extraction_fps
         self.resize_to_smaller_edge = args.resize_to_smaller_edge

--- a/models/raft/extract_raft.py
+++ b/models/raft/extract_raft.py
@@ -164,14 +164,14 @@ class ExtractRAFT(torch.nn.Module):
 
         return features_with_meta
 
-    def show_flow_for_every_pair_of_frames(self, flow_up: torch.Tensor, batch: torch.Tensor):
+    def show_flow_for_every_pair_of_frames(self, out: torch.Tensor, batch: torch.Tensor):
         '''Shows the resulting flow as well as the first frame
 
         Args:
-            flow_up (torch.Tensor): the output of the RAFT
+            out (torch.Tensor): the output of the model
             batch (torch.Tensor): the stack of rgb inputs
         '''
-        for idx, flow in enumerate(flow_up):
+        for idx, flow in enumerate(out):
             img = batch[idx].permute(1, 2, 0).cpu().numpy()
             flow = flow.permute(1, 2, 0).cpu().numpy()
             flow = flow_viz.flow_to_image(flow)

--- a/models/resnet/extract_resnet.py
+++ b/models/resnet/extract_resnet.py
@@ -37,9 +37,9 @@ class ExtractResNet(torch.nn.Module):
             transforms.Normalize(mean=TRAIN_MEAN, std=TRAIN_STD)
         ])
         self.show_pred = args.show_pred
+        # not used, create an issue if you would like to save the frames
         self.keep_tmp_files = args.keep_tmp_files
         self.on_extraction = args.on_extraction
-        # not used, create an issue if you would like to save the frames
         self.tmp_path = os.path.join(args.tmp_path, self.feature_type)
         self.output_path = os.path.join(args.output_path, self.feature_type)
         self.progress = tqdm(total=len(self.path_list))

--- a/models/vggish/extract_vggish.py
+++ b/models/vggish/extract_vggish.py
@@ -22,6 +22,8 @@ class ExtractVGGish(torch.nn.Module):
         self.tmp_path = os.path.join(args.tmp_path, self.feature_type)
         self.output_path = os.path.join(args.output_path, self.feature_type)
         self.progress = tqdm(total=len(self.path_list))
+        if args.show_pred:
+            raise NotImplementedError
 
     def forward(self, indices: torch.LongTensor):
         '''
@@ -50,9 +52,9 @@ class ExtractVGGish(torch.nn.Module):
             # update tqdm progress bar
             self.progress.update()
 
-    def extract(self, 
-                device: torch.device, 
-                model: torch.nn.Module, 
+    def extract(self,
+                device: torch.device,
+                model: torch.nn.Module,
                 video_path: Union[str, None] = None) -> Dict[str, np.ndarray]:
         '''The extraction call. Made to clean the forward call a bit.
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -111,14 +111,14 @@ def sanity_check(args: argparse.Namespace):
         args.device_ids = [args.device_ids[0]]
         if args.feature_type == 'vggish':
             print('Showing class predictions is not implemented for VGGish')
-    if args.feature_type == 'r21d_rgb':
+    if args.feature_type == 'r21d':
         message = 'torchvision.read_video only supports extraction at orig fps. Remove this argument.'
         assert args.extraction_fps is None, message
     if args.feature_type == 'i3d':
         message = f'I3D model does not support inputs shorter than 10 timestamps. You have: {args.stack_size}'
         if args.stack_size is not None:
             assert args.stack_size >= 10, message
-    if args.feature_type in ['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152', 'r21d_rgb']:
+    if args.feature_type in ['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152', 'r21d']:
         if args.keep_tmp_files:
             print('If you want to keep frames while extracting features, please create an issue')
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-import pathlib
+from pathlib import Path
 import subprocess
 from typing import Dict
 import pickle
@@ -65,7 +65,7 @@ def action_on_extraction(feats_dict: Dict[str, np.ndarray], video_path, output_p
             # make dir if doesn't exist
             os.makedirs(output_path, exist_ok=True)
             # extract file name and change the extention
-            fname = f'{pathlib.Path(video_path).stem}_{key}.npy'
+            fname = f'{Path(video_path).stem}_{key}.npy'
             # construct the paths to save the features
             fpath = os.path.join(output_path, fname)
             if key != 'fps' and len(value) == 0:
@@ -76,7 +76,7 @@ def action_on_extraction(feats_dict: Dict[str, np.ndarray], video_path, output_p
             # make dir if doesn't exist
             os.makedirs(output_path, exist_ok=True)
             # extract file name and change the extention
-            fname = f'{pathlib.Path(video_path).stem}_{key}.pkl'
+            fname = f'{Path(video_path).stem}_{key}.pkl'
             # construct the paths to save the features
             fpath = os.path.join(output_path, fname)
             if key != 'fps' and len(value) == 0:
@@ -178,7 +178,7 @@ def reencode_video_with_diff_fps(video_path: str, tmp_path: str, extraction_fps:
     os.makedirs(tmp_path, exist_ok=True)
 
     # form the path to tmp directory
-    new_path = os.path.join(tmp_path, f'{pathlib.Path(video_path).stem}_new_fps.mp4')
+    new_path = os.path.join(tmp_path, f'{Path(video_path).stem}_new_fps.mp4')
     cmd = f'{which_ffmpeg()} -hide_banner -loglevel panic '
     cmd += f'-y -i {video_path} -filter:v fps=fps={extraction_fps} {new_path}'
     subprocess.call(cmd.split())
@@ -216,3 +216,20 @@ def extract_wav_from_mp4(video_path: str, tmp_path: str) -> str:
     subprocess.call(aac_to_wav.split())
 
     return audio_wav_path, audio_aac_path
+
+
+def build_cfg_path(feature_type: str) -> os.PathLike:
+    '''Makes a path to the default config file for each feature family.
+
+    Args:
+        feature_type (str): the type (e.g. 'vggish')
+
+    Returns:
+        os.PathLike: the path to the default config for the type
+    '''
+    path_base = Path('./configs')
+    if feature_type in ['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152']:
+        path = path_base / 'resnet.yml'
+    else:
+        path = path_base / f'{feature_type}.yml'
+    return path


### PR DESCRIPTION
This PR opens opportunities for effortless and flexible configuration of the feature extraction. As a result, it should be pretty straightforward to create a Google Colab, for example. Now, a user can specify arguments that will be merged to the base configs (see `./configs`). Another useful outcome is the size of the `./main.py` after this change.

* Since the config system is OmegaConf, both envs have it as a dependency now.

* Also, the docs now have a Minimal Working Example section which shows a quick command to extract the features of a specific type. This MWE has `show_pred=true` that shows the outputs of the model from which we extract features. In the case of optical flow, it pops up the window showing optical flow frame visualization for the whole video; meanwhile, the action recognition and imagenet based models show the class distribution.

* Please note, now the CLI API changed a bit (e.g. `--device_ids 0 2` now `device_ids="[0, 2]"` or `--show_pred` now `show_pred=true`).

* Along with the config changes, I also renamed the R(2+1)d feature type: `r21d_rgb -> r21d`.

* Finally, `raft` now supports altering between KITTI and Sintel (default) fine-tuning (`finetuned_on` argument)