### PR TITLE
CF: load_model module in extractors; docs: PWC MWE

### DIFF
--- a/docs/models/pwc.md
+++ b/docs/models/pwc.md
@@ -16,12 +16,25 @@ conda env create -f conda_env_torch_pwc.yml
 
 ---
 
-## Examples
-Start by activating the environment
+## Minimal Working Example
+
 ```bash
+# Activate the environment
 conda activate pwc
+
+# extract optical flow from "./sample/v_GGSY1Qvo990.mp4" using one GPU and show the flow for each frame
+python main.py \
+    feature_type=pwc \
+    show_pred=true \
+    video_paths="[./sample/v_GGSY1Qvo990.mp4]"
+
+# if `show_pred=true`, the window with predictions will appear, use any key to show the next frame.
+# To use `show_pred=true`, a screen must be attached to the machine or X11 forwarding is enabled.
 ```
 
+---
+
+## Examples
 Please see the examples for [`RAFT`](raft.md) optical flow frame extraction. Make sure to replace `--feature_type` argument to `pwc`.
 
 ---

--- a/models/pwc/extract_pwc.py
+++ b/models/pwc/extract_pwc.py
@@ -52,12 +52,7 @@ class ExtractPWC(torch.nn.Module):
             indices {torch.LongTensor} -- indices to self.path_list
         '''
         device = indices.device
-
-        # load the model
-        model = PWCNet()
-        model.load_state_dict(torch.load(self.model_path, map_location=device))
-        model = model.to(device)
-        model.eval()
+        model = self.load_model(device)
 
         for idx in indices:
             # when error occurs might fail silently when run from torch data parallel
@@ -169,3 +164,18 @@ class ExtractPWC(torch.nn.Module):
             img_flow = np.concatenate([img, flow], axis=0)
             cv2.imshow('Press any key to see the next frame...', img_flow[:, :, [2, 1, 0]] / 255.0)
             cv2.waitKey()
+
+    def load_model(self, device: torch.device) -> torch.nn.Module:
+        '''Defines the models, loads checkpoints, sends them to the device.
+
+        Args:
+            device (torch.device): The device
+
+        Returns:
+            torch.nn.Module: flow extraction module.
+        '''
+        model = PWCNet()
+        model.load_state_dict(torch.load(self.model_path, map_location='cpu'))
+        model = model.to(device)
+        model.eval()
+        return model

--- a/models/raft/extract_raft.py
+++ b/models/raft/extract_raft.py
@@ -55,12 +55,7 @@ class ExtractRAFT(torch.nn.Module):
             indices {torch.LongTensor} -- indices to self.path_list
         '''
         device = indices.device
-
-        # load the model
-        model = RAFT()
-        model = torch.nn.DataParallel(model, device_ids=[device])
-        model.load_state_dict(torch.load(self.model_path, map_location=device))
-        model.eval()
+        model = self.load_model(device)
 
         for idx in indices:
             # when error occurs might fail silently when run from torch data parallel
@@ -178,3 +173,18 @@ class ExtractRAFT(torch.nn.Module):
             img_flow = np.concatenate([img, flow], axis=0)
             cv2.imshow('Press any key to see the next frame...', img_flow[:, :, [2, 1, 0]] / 255.0)
             cv2.waitKey()
+
+    def load_model(self, device: torch.device) -> torch.nn.Module:
+        '''Defines the models, loads checkpoints, sends them to the device.
+
+        Args:
+            device (torch.device)
+
+        Returns:
+            torch.nn.Module: the model
+        '''
+        model = RAFT()
+        model = torch.nn.DataParallel(model, device_ids=[device])
+        model.load_state_dict(torch.load(self.model_path, map_location=device))
+        model.eval()
+        return model

--- a/models/resnet/extract_resnet.py
+++ b/models/resnet/extract_resnet.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 
 import cv2
 import numpy as np
@@ -50,30 +50,12 @@ class ExtractResNet(torch.nn.Module):
             indices {torch.LongTensor} -- indices to self.path_list
         '''
         device = indices.device
-
-        if self.feature_type == 'resnet18':
-            model = models.resnet18
-        elif self.feature_type == 'resnet34':
-            model = models.resnet34
-        elif self.feature_type == 'resnet50':
-            model = models.resnet50
-        elif self.feature_type == 'resnet101':
-            model = models.resnet101
-        elif self.feature_type == 'resnet152':
-            model = models.resnet152
-        else:
-            raise NotImplementedError
-
-        model = model(pretrained=True).to(device)
-        model.eval()
-        # save the pre-trained classifier for show_preds and replace it in the net with identity
-        model_class = model.fc
-        model.fc = torch.nn.Identity()
+        model, class_head = self.load_model(device)
 
         for idx in indices:
             # when error occurs might fail silently when run from torch data parallel
             try:
-                feats_dict = self.extract(device, model, model_class, self.path_list[idx])
+                feats_dict = self.extract(device, model, class_head, self.path_list[idx])
                 action_on_extraction(feats_dict, self.path_list[idx], self.output_path, self.on_extraction)
             except KeyboardInterrupt:
                 raise KeyboardInterrupt
@@ -166,3 +148,36 @@ class ExtractResNet(torch.nn.Module):
         }
 
         return features_with_meta
+
+    def load_model(self, device: torch.device) -> Tuple[torch.nn.Module]:
+        '''Defines the models, loads checkpoints, sends them to the device.
+
+        Args:
+            device (torch.device): The device
+
+        Raises:
+            NotImplementedError: if flow type is not implemented.
+
+        Returns:
+            Tuple[torch.nn.Module]: the model with identity head, the original classifier
+        '''
+        if self.feature_type == 'resnet18':
+            model = models.resnet18
+        elif self.feature_type == 'resnet34':
+            model = models.resnet34
+        elif self.feature_type == 'resnet50':
+            model = models.resnet50
+        elif self.feature_type == 'resnet101':
+            model = models.resnet101
+        elif self.feature_type == 'resnet152':
+            model = models.resnet152
+        else:
+            raise NotImplementedError
+
+        model = model(pretrained=True)
+        model = model.to(device)
+        model.eval()
+        # save the pre-trained classifier for show_preds and replace it in the net with identity
+        class_head = model.fc
+        model.fc = torch.nn.Identity()
+        return model, class_head

--- a/models/vggish/extract_vggish.py
+++ b/models/vggish/extract_vggish.py
@@ -31,10 +31,7 @@ class ExtractVGGish(torch.nn.Module):
             indices {torch.LongTensor} -- indices to self.path_list
         '''
         device = indices.device
-
-        model = VGGish()
-        model = model.eval()
-        model = model.to(device)
+        model = self.load_model(device)
 
         for idx in indices:
             # when error occurs might fail silently when run from torch data parallel
@@ -93,3 +90,17 @@ class ExtractVGGish(torch.nn.Module):
         feats_dict = {self.feature_type: vggish_stack}
 
         return feats_dict
+
+    def load_model(self, device: torch.device) -> torch.nn.Module:
+        '''Defines the models, loads checkpoints, sends them to the device.
+
+        Args:
+            device (torch.device)
+
+        Returns:
+            torch.nn.Module: the model
+        '''
+        model = VGGish()
+        model = model.to(device)
+        model.eval()
+        return model


### PR DESCRIPTION
* now, each extractor has `load_model` method which will ease the import API for e.g. Google Colab. Plus, this might be a step to the OOP refactoring of the whole codebase but a bit later.
* a minimal working example for PWC. It is too abandoned otherwise.