### PR TITLE
CUDA 11 partial support

### DIFF
--- a/conda_env_torch_zoo.yml
+++ b/conda_env_torch_zoo.yml
@@ -9,10 +9,10 @@ dependencies:
   - av=8.0.2=py38he20a9df_1
   - blas=1.0=mkl
   - bzip2=1.0.8=h516909a_3
-  - ca-certificates=2021.10.8=ha878542_0
+  - ca-certificates=2021.10.26=h06a4308_2
   - certifi=2021.10.8=py38h578d9bd_1
   - cffi=1.14.6=py38h400218f_0
-  - cudatoolkit=10.2.89=hfd86e86_1
+  - cudatoolkit=11.0.221=h6bb024c_0
   - ffmpeg=4.3.1=h167e202_0
   - freetype=2.10.2=h5ab3b9f_0
   - gettext=0.19.8.1=h5e8e0c9_1
@@ -35,6 +35,7 @@ dependencies:
   - libsndfile=1.0.29=he1b5a44_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
   - libtiff=4.1.0=h2733197_1
+  - libuv=1.40.0=h7b6447c_0
   - libvorbis=1.3.7=he1b5a44_0
   - llvmlite=0.36.0=py38h612dafd_4
   - lz4-c=1.9.2=he6710b0_1
@@ -51,14 +52,14 @@ dependencies:
   - olefile=0.46=py_0
   - omegaconf=2.1.1=py38h578d9bd_1
   - openh264=2.1.1=h8b12597_0
-  - openssl=1.1.1h=h516909a_0
+  - openssl=1.1.1l=h7f8727e_0
   - pillow=7.2.0=py38hb39fc2d_0
   - pip=20.2.2=py38_0
   - pycparser=2.21=pyhd8ed1ab_0
   - pysoundfile=0.10.3.post1=pyhd3deb0d_0
   - python=3.8.5=h7579374_1
   - python_abi=3.8=1_cp38
-  - pytorch=1.6.0=py3.8_cuda10.2.89_cudnn7.6.5_0
+  - pytorch=1.7.1=py3.8_cuda11.0.221_cudnn8.0.5_0
   - pyyaml=5.3.1=py38h8df0ef7_1
   - readline=8.0=h7b6447c_0
   - resampy=0.2.2=py_0
@@ -68,7 +69,8 @@ dependencies:
   - sqlite=3.33.0=h62c20be_0
   - tbb=2020.2=hc9558a2_0
   - tk=8.6.10=hbc83047_0
-  - torchvision=0.7.0=py38_cu102
+  - torchaudio=0.7.2=py38
+  - torchvision=0.8.2=py38_cu110
   - tqdm=4.49.0=py_0
   - typing_extensions=4.0.1=pyha770c72_0
   - wheel=0.35.1=py_0

--- a/docs/models/i3d.md
+++ b/docs/models/i3d.md
@@ -7,6 +7,16 @@ The _Inflated 3D ([I3D](https://arxiv.org/abs/1705.07750))_ features are extract
 
 Please note, this implementation uses either [PWC-Net](https://arxiv.org/abs/1709.02371) (the default) and [RAFT](https://arxiv.org/abs/2003.12039) optical flow extraction instead of the TV-L1 algorithm, which was used in the original I3D paper as it hampers speed. Yet, it might possibly lead to worse peformance. Our tests show that the performance is reasonable. You may test it yourself by providing `--show_pred` flag.
 
+!!! warning "CUDA 11 and GPUs like RTX 3090 and newer"
+
+    PWC optical flow back-end is not supported on CUDA 11 and, therefore, GPUs like **RTX 3090** and newer.
+    RGB-only model should still work.
+    For details please check this [issue #13](https://github.com/v-iashin/video_features/issues/13)
+    If you were able to fix it, please share your workaround.
+    Feel free to use `flow_type=raft` [RAFT](raft.md) during extraction.
+
+---
+
 ---
 
 ## Set up the Environment for I3D

--- a/docs/models/pwc.md
+++ b/docs/models/pwc.md
@@ -5,13 +5,20 @@
 
 [PWC-Net: CNNs for Optical Flow Using Pyramid, Warping, and Cost Volume](https://arxiv.org/abs/1709.02371) frames are extracted for every consecutive pair of frames in a video. PWC-Net is pre-trained on [Sintel Flow dataset](http://sintel.is.tue.mpg.de/). The implementation follows [sniklaus/pytorch-pwc@f61389005](https://github.com/sniklaus/pytorch-pwc/tree/f6138900578214ab4e3daef6743b88f7824293be).
 
+!!! warning "CUDA 11 and GPUs like RTX 3090 and newer"
+
+    The current environment does not support **CUDA 11** and, therefore, GPUs like **RTX 3090** and newer.
+    For details please check this [issue #13](https://github.com/v-iashin/video_features/issues/13)
+    If you were able to fix it, please share your workaround.
+    If you need an optical flow extractor, you are recommended to use [RAFT](raft.md).
+
 ---
 
 ## Set up the Environment for PWC
-Setup `conda` environment. `conda_env_pwc.yml`
+Setup `conda` environment.
 ```bash
 # it will create a new conda environment called 'pwc' on your machine
-conda env create -f conda_env_torch_pwc.yml
+conda env create -f conda_env_pwc.yml
 ```
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,3 +4,5 @@ theme:
   palette:
     primary: red
 repo_url: https://github.com/v-iashin/video_features
+markdown_extensions:
+  - admonition


### PR DESCRIPTION
As discussed in #13, the environments did not support CUDA 11 and GPUs like 3090 and newer. Please see #13 for more details.

With this PR, I am fixing the main environment `torch_zoo`. This means that most of the models will support these GPUs, except for `pwc`  and i3d with `pwc` back-end (RAFT can be used but slower and does not seem to perform that well for I3D). 