### PR TITLE
Tests (CLI API)

### DIFF
--- a/docs/models/r21d.md
+++ b/docs/models/r21d.md
@@ -24,10 +24,10 @@ models are pre-trained on RGB frames and follow the plain
     significantly better performance than the default model
     (e.g. the `32` frame model reaches an accuracy of 79.10 vs 57.50 by default).
 
-By default (`--model_name=r2plus1d_18_16_kinetics`), the model expects to input a stack of 16 RGB frames (`112x112`),
+By default (`model_name=r2plus1d_18_16_kinetics`), the model expects to input a stack of 16 RGB frames (`112x112`),
 which spans 0.64 seconds of the video recorded at 25 fps.
 In the default case, the features will be of size `Tv x 512` where `Tv = duration / 0.64`.
-Specify, `model_name`, `--step_size` and `--stack_size` to change the default behavior.
+Specify, `model_name`, `step_size` and `stack_size` to change the default behavior.
 
 
 ---
@@ -69,11 +69,25 @@ conda activate torch_zoo
 It will extract R(2+1)d features for sample videos using 0th and 2nd devices in parallel. The features are going to be extracted with the default parameters.
 ```bash
 python main.py \
-    feature_type=r21d \
+    feature_type="r21d" \
     device_ids="[0, 2]" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
+
+Here is an example with `r2plus1d_34_32_ig65m_ft_kinetics` 34-layer R(2+1)D model
+that waas pre-trained on [IG-65M](https://arxiv.org/abs/1905.00561) and, then, fine-tuned on Kinetics 400
+```bash
+python main.py \
+    feature_type="r21d" \
+    model_name="r2plus1d_34_8_ig65m_ft_kinetics" \
+    device_ids="[0, 2]" \
+    video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
+```
+
+
 See [I3D Examples](i3d.md). Note, that this implementation of R(2+1)d only supports the RGB stream.
+
+
 
 ---
 

--- a/tests/clip/test_clip.py
+++ b/tests/clip/test_clip.py
@@ -1,4 +1,8 @@
+import pickle
+import numpy as np
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -9,7 +13,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.clip.extract_clip import ExtractCLIP as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -31,26 +35,68 @@ TO_MAKE_REF = False
     # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'RN50', 1, None, TO_MAKE_REF),
 ])
 def test(device, video_path, model_name, batch_size, extraction_fps, to_make_ref):
+    # calculate features with the 'import' API
     # output
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
     args.video_paths = video_path
     args.model_name = model_name
     args.batch_size = batch_size
     args.extraction_fps = extraction_fps
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model, class_head = extractor.load_model(device)
-    features_out = extractor.extract(device, model, class_head, video_path)
-    features_out = features_out[FEATURE_TYPE]
+    feat_out_import = extractor.extract(device, model, class_head, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += f' model_name="{model_name}"' if model_name else ''
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' batch_size={batch_size}' if batch_size else ''
+            cmd += f' extraction_fps={extraction_fps}' if extraction_fps else ''
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / model_name.replace("/", "_") / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+    # compare features saved by pickle and numpy
+    assert (feat_out_cmd['save_pickle'][FEATURE_TYPE] - feat_out_cmd['save_numpy'][FEATURE_TYPE]).sum() < 1e-6
+    # compare cmd API and import API. Assuming if it passes these tests, only `feat_out` will be used
+    assert (feat_out_cmd['save_numpy'][FEATURE_TYPE] - feat_out_import[FEATURE_TYPE]).sum() < 1e-6
+
+    feat_out = feat_out_import[FEATURE_TYPE]
     # load/make the reference (make ref will make the reference file which will be used to compare with)
     filename = f'{device}_{Path(video_path).stem}_{model_name.replace("/", "_")}_{batch_size}_{extraction_fps}.pt'
     ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
     if to_make_ref:
-        make_ref(args, video_path, features_out, ref_path)
-    features_ref = torch.load(ref_path)['data']
+        make_ref(args, video_path, feat_out, ref_path)
+    feat_ref = torch.load(ref_path)['data']
     # tests
-    print(features_out)
-    print(features_out.shape)
-    print(features_ref)
-    print(features_ref.shape)
-    assert features_out.shape == features_ref.shape
-    assert (features_out - features_ref).sum() < 1e-6
+    print(feat_out)
+    print(feat_out.shape)
+    print(feat_ref)
+    print(feat_ref.shape)
+    assert feat_out.shape == feat_ref.shape
+    assert (feat_out - feat_ref).sum() < 1e-6

--- a/tests/i3d/test_i3d.py
+++ b/tests/i3d/test_i3d.py
@@ -1,4 +1,8 @@
+import pickle
+import numpy as np
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -9,7 +13,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.i3d.extract_i3d import ExtractI3D as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -41,6 +45,7 @@ else:
 
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_path, streams, flow_type, stack_size, step_size, extraction_fps, to_make_ref):
+    # calculate features with the 'import' API
     # output
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
     args.video_paths = video_path
@@ -49,22 +54,65 @@ def test(device, video_path, streams, flow_type, stack_size, step_size, extracti
     args.stack_size = stack_size
     args.step_size = step_size
     args.extraction_fps = extraction_fps
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model, class_head = extractor.load_model(device)
-    features = extractor.extract(device, model, class_head, video_path)
-    for k in [key for key in features.keys() if key in ['rgb', 'flow']]:
-        features_out = features[k]
+    feat_out_import = extractor.extract(device, model, class_head, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += f' flow_type="{flow_type}"'
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' stack_size={stack_size}' if stack_size else ''
+            cmd += f' step_size={step_size}' if step_size else ''
+            cmd += f' extraction_fps={extraction_fps}' if extraction_fps else ''
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+
+    for k in [key for key in feat_out_import.keys() if key in ['rgb', 'flow']]:
+        # compare features saved by pickle and numpy
+        assert (feat_out_cmd['save_pickle'][key] - feat_out_cmd['save_numpy'][key]).sum() < 1e-6
+        # compare cmd API and import API. Assuming if it passes these tests, only `feat_out` will be used
+        assert (feat_out_cmd['save_numpy'][key] - feat_out_import[key]).sum() < 1e-6
+
+        feat_out = feat_out_import[k]
         # load/make the reference (make ref will make the reference file which will be used to compare with)
         filename = f'{device}_{Path(video_path).stem}_{streams}_{flow_type}_{stack_size}_{step_size}_{extraction_fps}_{k}.pt'
         ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
         if to_make_ref:
-            make_ref(args, video_path, features_out, ref_path)
-        features_ref = torch.load(ref_path)['data']
+            make_ref(args, video_path, feat_out, ref_path)
+        feat_ref = torch.load(ref_path)['data']
         # tests
         print(k)
-        print(features_out)
-        print(features_out.shape)
-        print(features_ref)
-        print(features_ref.shape)
-        assert features_out.shape == features_ref.shape
-        assert (features_out - features_ref).sum() < 1e-6
+        print(feat_out)
+        print(feat_out.shape)
+        print(feat_ref)
+        print(feat_ref.shape)
+        assert feat_out.shape == feat_ref.shape
+        assert (feat_out - feat_ref).sum() < 1e-6

--- a/tests/i3d/test_i3d.py
+++ b/tests/i3d/test_i3d.py
@@ -70,7 +70,7 @@ def test(device, video_path, streams, flow_type, stack_size, step_size, extracti
             # make a cmd (the quotation of arguments might lead to unwanted fails :/)
             cmd = f'{sys.executable} main.py'
             cmd += f' feature_type="{FEATURE_TYPE}"'
-            cmd += f' flow_type="{flow_type}"'
+            cmd += f' flow_type="{flow_type}"' if flow_type else ''
             cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
             cmd += f' stack_size={stack_size}' if stack_size else ''
             cmd += f' step_size={step_size}' if step_size else ''

--- a/tests/pwc/test_pwc.py
+++ b/tests/pwc/test_pwc.py
@@ -2,6 +2,10 @@
     The content of this file is commented to avoid parsing it with pytest test discovery.
     Since PWC optical flow extraction depends on another env
 '''
+import pickle
+import numpy as np
+import tempfile
+import subprocess
 import sys
 from pathlib import Path
 
@@ -13,7 +17,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.pwc.extract_pwc import ExtractPWC as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -30,25 +34,66 @@ TO_MAKE_REF = False
     # ('cuda', './sample/v_GGSY1Qvo990.mp4', 384, 5, TO_MAKE_REF),  # 345M
 ])
 def test(device, video_path, side_size, extraction_fps, to_make_ref):
+    # calculate features with the 'import' API
     # output
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
     args.video_paths = video_path
     args.side_size = side_size
     args.extraction_fps = extraction_fps
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model = extractor.load_model(device)
-    features_out = extractor.extract(device, model, video_path)
-    features_out = features_out[FEATURE_TYPE]
+    feat_out_import = extractor.extract(device, model, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' side_size={side_size}' if side_size else ''
+            cmd += f' extraction_fps={extraction_fps}' if extraction_fps else ''
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+    # compare features saved by pickle and numpy
+    assert (feat_out_cmd['save_pickle'][FEATURE_TYPE] - feat_out_cmd['save_numpy'][FEATURE_TYPE]).sum() < 1e-6
+    # compare cmd API and import API. Assuming if it passes these tests, only `feat_out` will be used
+    assert (feat_out_cmd['save_numpy'][FEATURE_TYPE] - feat_out_import[FEATURE_TYPE]).sum() < 1e-6
+
+    feat_out = feat_out_import[FEATURE_TYPE]
     # load/make the reference (make ref will make the reference file which will be used to compare with)
     filename = f'{device}_{Path(video_path).stem}_{side_size}_{extraction_fps}.pt'
     ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
     if to_make_ref:
-        make_ref(args, video_path, features_out, ref_path)
-    features_ref = torch.load(ref_path)['data']
+        make_ref(args, video_path, feat_out, ref_path)
+    feat_ref = torch.load(ref_path)['data']
     # tests
-    print(features_out)
-    print(features_out.shape)
-    print(features_ref)
-    print(features_ref.shape)
-    assert features_out.shape == features_ref.shape
-    assert (features_out - features_ref).sum() < 1e-6
+    print(feat_out)
+    print(feat_out.shape)
+    print(feat_ref)
+    print(feat_ref.shape)
+    assert feat_out.shape == feat_ref.shape
+    assert (feat_out - feat_ref).sum() < 1e-6

--- a/tests/r21d/test_r21d.py
+++ b/tests/r21d/test_r21d.py
@@ -1,3 +1,7 @@
+import pickle
+import numpy as np
+import tempfile
+import subprocess
 import sys
 from pathlib import Path
 
@@ -9,7 +13,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.r21d.extract_r21d import ExtractR21D as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -27,27 +31,72 @@ TO_MAKE_REF = False
     ('cuda', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, 1, TO_MAKE_REF),
 ])
 def test(device, video_path, model_name, stack_size, step_size, extraction_fps, to_make_ref):
-    # output
+    # calculate features with the 'import' API
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
+    # patch the config
     args.video_paths = video_path
     args.model_name = model_name
     args.stack_size = stack_size
     args.step_size = step_size
     args.extraction_fps = extraction_fps
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model, class_head = extractor.load_model(device)
-    features_out = extractor.extract(device, model, class_head, video_path)
-    features_out = features_out[FEATURE_TYPE]
+    # extract features
+    feat_out_import = extractor.extract(device, model, class_head, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += f' model_name="{model_name}"' if model_name else ''
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' stack_size={stack_size}' if stack_size else ''
+            cmd += f' step_size={step_size}' if step_size else ''
+            cmd += f' extraction_fps="{extraction_fps}"' if extraction_fps else ''
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / model_name / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+    # compare features saved by pickle and numpy
+    assert (feat_out_cmd['save_pickle'][FEATURE_TYPE] - feat_out_cmd['save_numpy'][FEATURE_TYPE]).sum() < 1e-6
+    # compare cmd API and import API. Assuming if it passes these tests, only `feat_out` will be used
+    assert (feat_out_cmd['save_numpy'][FEATURE_TYPE] - feat_out_import[FEATURE_TYPE]).sum() < 1e-6
+
+    # Assuming if it passes the previous tests, I will use only the feats from 'import' API
+    feat_out = feat_out_import[FEATURE_TYPE]
     # load/make the reference (make ref will make the reference file which will be used to compare with)
     filename = f'{device}_{Path(video_path).stem}_{model_name}_{stack_size}_{step_size}_{extraction_fps}.pt'
     ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
     if to_make_ref:
-        make_ref(args, video_path, features_out, ref_path)
-    features_ref = torch.load(ref_path)['data']
+        make_ref(args, video_path, feat_out, ref_path)
+    feat_ref = torch.load(ref_path)['data']
     # tests
-    print(features_out)
-    print(features_out.shape)
-    print(features_ref)
-    print(features_ref.shape)
-    assert features_out.shape == features_ref.shape
-    assert (features_out - features_ref).sum() < 1e-6
+    print(feat_out)
+    print(feat_out.shape)
+    print(feat_ref)
+    print(feat_ref.shape)
+    assert feat_out.shape == feat_ref.shape
+    assert (feat_out - feat_ref).sum() < 1e-6

--- a/tests/raft/test_raft.py
+++ b/tests/raft/test_raft.py
@@ -1,3 +1,7 @@
+import pickle
+import numpy as np
+import tempfile
+import subprocess
 import sys
 from pathlib import Path
 
@@ -9,7 +13,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.raft.extract_raft import ExtractRAFT as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -31,6 +35,7 @@ TO_MAKE_REF = False
     ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, 1, TO_MAKE_REF), # 17M
 ])
 def test(device, video_path, finetuned_on, batch_size, side_size, resize_to_smaller_edge, extraction_fps, to_make_ref):
+    # calculate features with the 'import' API
     # output
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
     args.video_paths = video_path
@@ -39,20 +44,66 @@ def test(device, video_path, finetuned_on, batch_size, side_size, resize_to_smal
     args.side_size = side_size
     args.resize_to_smaller_edge = resize_to_smaller_edge
     args.extraction_fps = extraction_fps
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model = extractor.load_model(device)
-    features_out = extractor.extract(device, model, video_path)
-    features_out = features_out[FEATURE_TYPE]
+    # extract features
+    feat_out_import = extractor.extract(device, model, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' finetuned_on="{finetuned_on}"'
+            cmd += f' batch_size={batch_size}' if batch_size else ''
+            cmd += f' side_size={side_size}' if side_size else ''
+            cmd += f' resize_to_smaller_edge={resize_to_smaller_edge}'
+            cmd += f' extraction_fps={extraction_fps}' if extraction_fps else ''
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+    # compare features saved by pickle and numpy
+    assert (feat_out_cmd['save_pickle'][FEATURE_TYPE] - feat_out_cmd['save_numpy'][FEATURE_TYPE]).sum() < 1e-6
+    # compare cmd API and import API. Assuming if it passes these tests, only `feat_out` will be used
+    assert (feat_out_cmd['save_numpy'][FEATURE_TYPE] - feat_out_import[FEATURE_TYPE]).sum() < 1e-6
+
+
+    # Assuming if it passes the previous tests, I will use only the feats from 'import' API
+    feat_out = feat_out_import[FEATURE_TYPE]
     # load/make the reference (make ref will make the reference file which will be used to compare with)
     filename = f'{device}_{Path(video_path).stem}_{finetuned_on}_{batch_size}_{side_size}_{resize_to_smaller_edge}_{extraction_fps}.pt'
     ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
     if to_make_ref:
-        make_ref(args, video_path, features_out, ref_path)
-    features_ref = torch.load(ref_path)['data']
+        make_ref(args, video_path, feat_out, ref_path)
+    feat_ref = torch.load(ref_path)['data']
     # tests
-    print(features_out)
-    print(features_out.shape)
-    print(features_ref)
-    print(features_ref.shape)
-    assert features_out.shape == features_ref.shape
-    assert (features_out - features_ref).sum() < 1e-6
+    print(feat_out)
+    print(feat_out.shape)
+    print(feat_ref)
+    print(feat_ref.shape)
+    assert feat_out.shape == feat_ref.shape
+    assert (feat_out - feat_ref).sum() < 1e-6

--- a/tests/resnet/test_resnet.py
+++ b/tests/resnet/test_resnet.py
@@ -1,3 +1,8 @@
+import pickle
+import numpy as np
+import subprocess
+import sys
+import tempfile
 import sys
 from pathlib import Path
 
@@ -9,7 +14,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.resnet.extract_resnet import ExtractResNet as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -26,26 +31,63 @@ TO_MAKE_REF = False
     ('cuda', './sample/v_GGSY1Qvo990.mp4', 'resnet34', 64, None, TO_MAKE_REF),
 ])
 def test(device, video_path, model_name, batch_size, extraction_fps, to_make_ref):
+    # calculate features with the 'import' API
     # output
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
     args.video_paths = video_path
     args.model_name = model_name
     args.batch_size = batch_size
     args.extraction_fps = extraction_fps
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model, class_head = extractor.load_model(device)
-    features_out = extractor.extract(device, model, class_head, video_path)
-    features_out = features_out[FEATURE_TYPE]
+    feat_out_import = extractor.extract(device, model, class_head, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += f' model_name="{model_name}"' if model_name else ''
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' batch_size={batch_size}' if batch_size else ''
+            cmd += f' extraction_fps={extraction_fps}' if extraction_fps else ''
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / model_name.replace("/", "_") / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+    feat_out = feat_out_import[FEATURE_TYPE]
     # load/make the reference (make ref will make the reference file which will be used to compare with)
     filename = f'{device}_{Path(video_path).stem}_{model_name}_{batch_size}_{extraction_fps}.pt'
     ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
     if to_make_ref:
-        make_ref(args, video_path, features_out, ref_path)
-    features_ref = torch.load(ref_path)['data']
+        make_ref(args, video_path, feat_out, ref_path)
+    feat_ref = torch.load(ref_path)['data']
     # tests
-    print(features_out)
-    print(features_out.shape)
-    print(features_ref)
-    print(features_ref.shape)
-    assert features_out.shape == features_ref.shape
-    assert (features_out - features_ref).sum() < 1e-6
+    print(feat_out)
+    print(feat_out.shape)
+    print(feat_ref)
+    print(feat_ref.shape)
+    assert feat_out.shape == feat_ref.shape
+    assert (feat_out - feat_ref).sum() < 1e-6

--- a/tests/vggish/test_vggish.py
+++ b/tests/vggish/test_vggish.py
@@ -1,3 +1,8 @@
+import pickle
+import numpy as np
+import subprocess
+import sys
+import tempfile
 import sys
 from pathlib import Path
 
@@ -9,7 +14,7 @@ sys.path.insert(0, '.')  # nopep8
 
 from models.vggish.extract_vggish import ExtractVGGish as Extractor
 from tests.utils import make_ref
-from utils.utils import build_cfg_path
+from utils.utils import build_cfg_path, on_after_sanity_check, sanity_check
 
 # a bit ugly but it assumes the features being tested has the same folder name,
 # e.g. for r21d: ./tests/r21d/THIS_FILE
@@ -24,23 +29,57 @@ TO_MAKE_REF = False
     ('cuda', './sample/v_GGSY1Qvo990.mp4', TO_MAKE_REF),
 ])
 def test(device, video_path, to_make_ref):
+    # calculate features with the 'import' API
     # output
     args = OmegaConf.load(build_cfg_path(FEATURE_TYPE))
     args.video_paths = video_path
+    sanity_check(args)
+    on_after_sanity_check(args)
+    # init the extractor
     extractor = Extractor(args)
     model = extractor.load_model(device)
-    features_out = extractor.extract(device, model, video_path)
-    features_out = features_out[FEATURE_TYPE]
+    feat_out_import = extractor.extract(device, model, video_path)
+
+    # calculate features with the 'cmd' API
+    with tempfile.TemporaryDirectory(suffix='_todel_video_features') as output_root:
+        ways_to_save = ['save_numpy', 'save_pickle']
+        feat_out_cmd = {k: dict() for k in ways_to_save}
+        # we are going to test both: `save_numpy` and `save_pickle`
+        for on_extraction in ways_to_save:
+            # make a cmd (the quotation of arguments might lead to unwanted fails :/)
+            cmd = f'{sys.executable} main.py'
+            cmd += f' feature_type="{FEATURE_TYPE}"'
+            cmd += ' device_ids=0' if device == 'cuda' else ' cpu="true"'
+            cmd += f' on_extraction="{on_extraction}"' if on_extraction else ''
+            cmd += f' video_paths={video_path}'
+            cmd += f' output_path="{output_root}"'
+            # damn, it is ugly
+            # call the cmd
+            subprocess.call(cmd.split())
+            # read from the saved file
+            for key in feat_out_import.keys():
+                # for search: `output_path`
+                # TODO: fix this as it now hard-coded by during extration it is in `on_after_sanity_check`
+                load_path_stub = Path(output_root) / FEATURE_TYPE / f'{Path(video_path).stem}_{key}'
+                if on_extraction == 'save_numpy':
+                    assert load_path_stub.with_suffix('.npy').exists(), (load_path_stub, output_root)
+                    feat = np.load(load_path_stub.with_suffix('.npy'))
+                elif on_extraction == 'save_pickle':
+                    assert load_path_stub.with_suffix('.pkl').exists()
+                    feat = pickle.load(open(load_path_stub.with_suffix('.pkl'), 'rb'))
+                feat_out_cmd[on_extraction][key] = feat
+
+    feat_out = feat_out_import[FEATURE_TYPE]
     # load/make the reference (make ref will make the reference file which will be used to compare with)
     filename = f'{device}_{Path(video_path).stem}.pt'
     ref_path = Path('./tests') / FEATURE_TYPE / 'reference' / filename
     if to_make_ref:
-        make_ref(args, video_path, features_out, ref_path)
-    features_ref = torch.load(ref_path)['data']
+        make_ref(args, video_path, feat_out, ref_path)
+    feat_ref = torch.load(ref_path)['data']
     # tests
-    print(features_out)
-    print(features_out.shape)
-    print(features_ref)
-    print(features_ref.shape)
-    assert features_out.shape == features_ref.shape
-    assert (features_out - features_ref).sum() < 1e-6
+    print(feat_out)
+    print(feat_out.shape)
+    print(feat_ref)
+    print(feat_ref.shape)
+    assert feat_out.shape == feat_ref.shape
+    assert (feat_out - feat_ref).sum() < 1e-6

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -115,7 +115,7 @@ def sanity_check(args: Union[argparse.Namespace, DictConfig]):
     assert len(filenames) == len(set(filenames)), 'Non-unique filenames. See video_features/issues/54'
     assert os.path.relpath(args.output_path) != os.path.relpath(args.tmp_path), 'The same path for out & tmp'
     if args.show_pred:
-        if args.cpu is False:
+        if not args.cpu:
             print('You want to see predictions. So, I will use only the first GPU from the list you specified.')
             args.device_ids = [args.device_ids[0]]
         if args.feature_type == 'vggish':
@@ -132,6 +132,8 @@ def sanity_check(args: Union[argparse.Namespace, DictConfig]):
             print('If you want to keep frames while extracting features, please create an issue')
     if args.feature_type == 'pwc' or (args.feature_type == 'i3d' and args.flow_type == 'pwc'):
         assert not args.cpu, 'PWC does NOT support using CPU'
+    if isinstance(args.device_ids, int):
+        args.device_ids = [args.device_ids]
 
 
 def form_list_from_user_input(args: Union[argparse.Namespace, DictConfig]) -> list:


### PR DESCRIPTION
This accompanies #48.

The testing logic is quite simple:
1. Calculate features with the 'import API'.
2. Calculate features with the 'CLI API' for `save_numpy` and `save_pickle`
3. Test: Compare features obtained with `save_numpy` and `save_pickle`
4. Test: Compare features from either `save_numpy` or `save_pickle` with the features from 'import API'
5. Test: compare the features with import API with the reference.

By doing these comparisons, we can be sure:
1. that 'import API' and 'CLI API' produce the same features
2. that `save_numpy` and `save_pickle` produce the same features

I also tested these in Docker. Surprisingly, I3D tests fail from inside of the Docker with CUDABLAS error which might be related to the GPU being OOM. I could workaround it by running the tests again solely on i3d and they passed. Since it is not related to the values, I will ignore it for now