### PR TITLE
The grand simplification - regressing to a single GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ documentation page.
 ## Multi-GPU and Multi-Node Setups
 
 With `video_features`, it is easy to parallelize feature extraction among many GPUs.
-To extract features in parallel on many GPUs, it is enough to start the script in another terminal
+It is enough to start the script in another terminal with another GPU (or even the same one)
 pointing to the same output folder and input video paths.
 The script will check if the features already exist and skip them.
-It also tries to load the feature file to check if it is corrupted (i.e. not openable).
+It will also try to load the feature file to check if it is corrupted (i.e. not openable).
 This approach allows you to continue feature extraction if the previous script failed for some reason.
 
-Similarly, we may start many single-GPU jobs on a GPU cluster with shared disk space and scale
-extraction with as many GPUs as you have.
+If you have an access to a GPU cluster with shared disk space you may scale
+extraction with as many GPUs as you can by creating several single-GPU jobs with the same command.
 
-Since each time the script is run the list of input files is shuffled you don't need to worry that
+Since each time the script is run the list of input files is shuffled, you don't need to worry that
 workers will be processing the same video.
 On a rare occasion when the collision happens, the script will rewrite previously extracted features.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 <img  src="https://github.com/v-iashin/v-iashin.github.io/raw/master/images/video_features/vid_feats.gif" width="300" />
 
-`video_features` allows you to extract features from raw videos in parallel with multiple GPUs.
-It supports several extractors that capture visual appearance, optical flow, and audio features.
+`video_features` allows you to extract features from video clips.
+It supports a variety of extractors and modalities,
+i.e. visual appearance, optical flow, and audio.
 See more details in [Documentation](https://v-iashin.github.io/video_features/).
 </div>
 
@@ -29,11 +30,11 @@ conda activate torch_zoo
 # extract r(2+1)d features for the sample videos
 python main.py \
     feature_type=r21d \
-    device_ids="[0]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 
-# use `device_ids="[0, 2]"` to run on 0th and 2nd devices in parallel
-# or add `cpu=true` to use CPU
+# if you have many GPUs, just run this command from another terminal with another device
+# device can also be "cpu"
 ```
 
 If you are more comfortable with Docker, there is a

--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ i.e. visual appearance, optical flow, and audio.
 See more details in [Documentation](https://v-iashin.github.io/video_features/).
 </div>
 
+## Supported Models
+
+Action Recognition
+
+- [I3D-Net RGB + Flow (Kinetics 400)](https://v-iashin.github.io/video_features/models/i3d)
+- [R(2+1)d RGB (IG-65M, Kinetics 400)](https://v-iashin.github.io/video_features/models/r21d)
+
+Sound Recognition
+
+- [VGGish (AudioSet)](https://v-iashin.github.io/video_features/models/vggish)
+
+Optical Flow
+
+- [RAFT (FlyingChairs, FlyingThings3D, Sintel, KITTI)](https://v-iashin.github.io/video_features/models/raft)
+- [PWC-Net (Sintel)](https://v-iashin.github.io/video_features/models/pwc/)
+
+Frame-wise Features
+
+- [CLIP](https://v-iashin.github.io/video_features/models/clip)
+- [ResNet-18,34,50,101,152 (ImageNet)](https://v-iashin.github.io/video_features/models/resnet)
+
+
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1csJgkVQ3E2qOyVlcOM-ACHGgPBBKwE2Y?usp=sharing)
@@ -43,29 +65,22 @@ Check out the
 [Docker support](https://v-iashin.github.io/video_features/meta/docker).
 documentation page.
 
-## Supported models
 
-Action Recognition
+## Multi-GPU and Multi-Node Setups
 
-- [I3D-Net RGB + Flow (Kinetics 400)](https://v-iashin.github.io/video_features/models/i3d)
-- [R(2+1)d RGB (IG-65M, Kinetics 400)](https://v-iashin.github.io/video_features/models/r21d)
+With `video_features`, it is easy to parallelize feature extraction among many GPUs.
+To extract features in parallel on many GPUs, it is enough to start the script in another terminal
+pointing to the same output folder and input video paths.
+The script will check if the features already exist and skip them.
+It also tries to load the feature file to check if it is corrupted (i.e. not openable).
+This approach allows you to continue feature extraction if the previous script failed for some reason.
 
-Sound Recognition
+Similarly, we may start many single-GPU jobs on a GPU cluster with shared disk space and scale
+extraction with as many GPUs as you have.
 
-- [VGGish (AudioSet)](https://v-iashin.github.io/video_features/models/vggish)
-
-Optical Flow
-
-- [RAFT (FlyingChairs, FlyingThings3D, Sintel, KITTI)](https://v-iashin.github.io/video_features/models/raft)
-- [PWC-Net (Sintel)](https://v-iashin.github.io/video_features/models/pwc)
-
-Image Recognition
-
-- [ResNet-18,34,50,101,152 (ImageNet)](https://v-iashin.github.io/video_features/models/resnet)
-
-Language-Image Pretraining
-
-- [CLIP](https://v-iashin.github.io/video_features/models/clip)
+Since each time the script is run the list of input files is shuffled you don't need to worry that
+workers will be processing the same video.
+On a rare occasion when the collision happens, the script will rewrite previously extracted features.
 
 ## Used in
 
@@ -77,5 +92,6 @@ Please, let me know if you found this repo useful for your projects or papers.
 
 ## Acknowledgements
 
-- [@Kamino666](https://github.com/Kamino666): added CLIP model as well as Windows and CPU support
+- [@Kamino666](https://github.com/Kamino666): added CLIP model as well as Windows and CPU support (and
+many other small things).
 - [@ohjho](https://github.com/ohjho): added support of 37-layer R(2+1)d favors.

--- a/configs/clip.yml
+++ b/configs/clip.yml
@@ -5,8 +5,7 @@ batch_size: 1 # Batchsize (only frame-wise extractors are supported)
 extraction_fps: null # For original video fps, leave unspecified "null" (None)
 
 # Extraction Parameters
-cpu: false # using cpu. If cpu=true, `device_ids` has no use
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/configs/i3d.yml
+++ b/configs/i3d.yml
@@ -7,8 +7,7 @@ flow_type: 'pwc' # Flow to use in I3D. 'pwc' (PWCNet) is faster while 'raft' (RA
 extraction_fps: null # For original video fps, leave as "null" (None)
 
 # Extraction Parameters
-cpu: false # using cpu. If cpu=true, `device_ids` has no use
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/configs/pwc.yml
+++ b/configs/pwc.yml
@@ -7,7 +7,7 @@ resize_to_smaller_edge: true # if false, the larger edge will be used to be resi
 # Extraction Parameters
 cpu: false # pwc does NOT support using CPU
 batch_size: 1 # increase the extraction speed with batching
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/configs/r21d.yml
+++ b/configs/r21d.yml
@@ -6,8 +6,7 @@ step_size: null # Feature step size in fps
 extraction_fps: null # For original video fps, leave unspecified "null" (None)
 
 # Extraction Parameters
-cpu: false # using cpu. If cpu=true, `device_ids` has no use
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/configs/raft.yml
+++ b/configs/raft.yml
@@ -6,9 +6,8 @@ resize_to_smaller_edge: true # if false, the larger edge will be used to be resi
 finetuned_on: 'sintel' # also 'kitti' is supported
 
 # Extraction Parameters
-cpu: false # using cpu. If cpu=true, `device_ids` has no use
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 batch_size: 1 # increase the extraction speed with batching
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/configs/resnet.yml
+++ b/configs/resnet.yml
@@ -5,8 +5,7 @@ batch_size: 1 # Batchsize (only frame-wise extractors are supported)
 extraction_fps: null # For original video fps, leave unspecified "null" (None)
 
 # Extraction Parameters
-cpu: false # using cpu. If cpu=true, `device_ids` has no use
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/configs/vggish.yml
+++ b/configs/vggish.yml
@@ -2,8 +2,7 @@
 feature_type: 'vggish'
 
 # Extraction Parameters
-cpu: false # using cpu. If cpu=true, `device_ids` has no use
-device_ids: [0]  # list of device ids. Use [0, 2] to employ the 0th and 2nd devices.
+device: 'cuda:0'  # device as in `torch`, can be 'cpu'
 on_extraction: 'print'  # what to do once the features are extracted. Can be ['print', 'save_numpy', 'save_pickle']
 output_path: './output' # where to store results if saved
 tmp_path: './tmp' # folder to store the temporary files used for extraction (frames or aud files)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,9 @@
   <img src="_assets/base.png" width="300" />
 </figure>
 
-`video_features` allows you to extract features from raw videos in parallel with multiple GPUs.
-It supports several extractors that capture visual appearance, optical flow, and audio features.
+`video_features` allows you to extract features from video clips.
+It supports a variety of extractors and modalities,
+i. e. visual appearance, optical flow, and audio.
 
 ## Quick Start
 
@@ -24,11 +25,10 @@ conda activate torch_zoo
 # extract r(2+1)d features for the sample videos
 python main.py \
     feature_type=r21d \
-    device_ids="[0]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
-
-# use `device_ids="[0, 2]"` to run on 0th and 2nd devices in parallel
-# or add `cpu=true` to use CPU
+# if you have many GPUs, just run this command from another terminal with another device
+# device can also be "cpu"
 ```
 
 If you are more comfortable with Docker, there is a

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,8 @@ documentation page.
 ## Multi-GPU and Multi-Node Setups
 
 With `video_features`, it is easy to parallelize feature extraction among many GPUs.
-It is enough to start the script in another terminal pointing to the same output folder and input video paths.
+It is enough to start the script in another terminal with another GPU (or even the same one)
+pointing to the same output folder and input video paths.
 The script will check if the features already exist and skip them.
 It will also try to load the feature file to check if it is corrupted (i.e. not openable).
 This approach allows you to continue feature extraction if the previous script failed for some reason.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,28 @@
 It supports a variety of extractors and modalities,
 i. e. visual appearance, optical flow, and audio.
 
+## Supported Models
+
+Action Recognition
+
+- [I3D-Net RGB + Flow (Kinetics 400)](https://v-iashin.github.io/video_features/models/i3d)
+- [R(2+1)d RGB (IG-65M, Kinetics 400)](https://v-iashin.github.io/video_features/models/r21d)
+
+Sound Recognition
+
+- [VGGish (AudioSet)](https://v-iashin.github.io/video_features/models/vggish)
+
+Optical Flow
+
+- [RAFT (FlyingChairs, FlyingThings3D, Sintel, KITTI)](https://v-iashin.github.io/video_features/models/raft)
+- [PWC-Net (Sintel)](https://v-iashin.github.io/video_features/models/pwc/)
+
+Frame-wise Features
+
+- [CLIP](https://v-iashin.github.io/video_features/models/clip)
+- [ResNet-18,34,50,101,152 (ImageNet)](https://v-iashin.github.io/video_features/models/resnet)
+
+
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1csJgkVQ3E2qOyVlcOM-ACHGgPBBKwE2Y?usp=sharing)
@@ -37,31 +59,33 @@ Check out the
 [Docker support](https://v-iashin.github.io/video_features/meta/docker).
 documentation page.
 
-## Supported Models
 
-Action Recognition
+## Multi-GPU and Multi-Node Setups
 
-- [I3D-Net RGB + Flow (Kinetics 400)](https://v-iashin.github.io/video_features/models/i3d)
-- [R(2+1)d RGB (IG-65M, Kinetics 400)](https://v-iashin.github.io/video_features/models/r21d)
+With `video_features`, it is easy to parallelize feature extraction among many GPUs.
+It is enough to start the script in another terminal pointing to the same output folder and input video paths.
+The script will check if the features already exist and skip them.
+It will also try to load the feature file to check if it is corrupted (i.e. not openable).
+This approach allows you to continue feature extraction if the previous script failed for some reason.
 
-Sound Recognition
+If you have an access to a GPU cluster with shared disk space you may scale
+extraction with as many GPUs as you can by creating several single-GPU jobs with the same command.
 
-- [VGGish (AudioSet)](https://v-iashin.github.io/video_features/models/vggish)
+Since each time the script is run the list of input files is shuffled, you don't need to worry that
+workers will be processing the same video.
+On a rare occasion when the collision happens, the script will rewrite previously extracted features.
 
-Optical Flow
+## Used in
 
-- [RAFT (FlyingChairs, FlyingThings3D, Sintel, KITTI)](https://v-iashin.github.io/video_features/models/raft)
-- [PWC-Net (Sintel)](https://v-iashin.github.io/video_features/models/pwc/)
+* [SpecVQGAN](https://arxiv.org/abs/2110.08791) branch `specvqgan`
+* [BMT](https://arxiv.org/abs/2005.08271) branch `bmt`
+* [MDVC](https://arxiv.org/abs/2003.07758) branch `mdvc`
 
-Image Recognition
+Please, let me know if you found this repo useful for your projects or papers.
 
-- [ResNet-18,34,50,101,152 (ImageNet)](https://v-iashin.github.io/video_features/models/resnet)
-
-Language-Image Pretraining
-
-- [CLIP](https://v-iashin.github.io/video_features/models/clip)
 
 ## Acknowledgements
 
-- [@Kamino666](https://github.com/Kamino666): added CLIP model as well as Windows and CPU support
+- [@Kamino666](https://github.com/Kamino666): added CLIP model as well as Windows and CPU support (and
+many other small things).
 - [@ohjho](https://github.com/ohjho): added support of 37-layer R(2+1)d favors.

--- a/docs/meta/docker.md
+++ b/docs/meta/docker.md
@@ -53,7 +53,7 @@ Finally, try to extract video features:
 # ubuntu@56b1bf77a20c:~/video_features $
 python main.py \
     feature_type=r21d \
-    device_ids="[0]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
@@ -95,7 +95,7 @@ For instance:
 # ubuntu@56b1bf77a20c:~/video_features $
 python main.py \
     feature_type=r21d \
-    device_ids="[0]" \
+    device="cuda:0" \
     video_paths="[./dataset/vid_1.mp4, ./dataset/vid_2.mp4]" \
     on_extraction="save_numpy"
 # you should have features in `./output`

--- a/docs/models/clip.md
+++ b/docs/models/clip.md
@@ -51,8 +51,10 @@ conda activate torch_zoo
 ```
 
 It is pretty much the same procedure as with other features.
-Here we take `ViT/B-32` as an example, but we also support `ViT-B/16`, `RN50x16`, `RN50x4`, `RN101`, `RN50` and others in [OpenAI CLIP implementation](https://github.com/openai/CLIP).
-In addition, if you want to use your weights, you need to copy your weights to `models/clip/checkpoints`, rename it `CLIP-custom.pth` and specify `model_name=custom`.
+Here we take `ViT/B-32` as an example, but we also support `ViT-B/16`, `RN50x16`, `RN50x4`, `RN101`, `RN50`
+and others in [OpenAI CLIP implementation](https://github.com/openai/CLIP).
+In addition, if you want to use your weights, you need to copy your weights to
+`models/clip/checkpoints`, rename it `CLIP-custom.pth` and specify `model_name=custom`.
 ```bash
 python main.py \
     feature_type="clip" \
@@ -60,7 +62,9 @@ python main.py \
     device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
-If you would like to save the features, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the features are saved in `./output/` or where `--output_path` specifies. In the case of frame-wise features, besides features, it also saves timestamps in ms and the original fps of the video into the same folder with features.
+If you would like to save the features, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the features are saved in `./output/` or where `--output_path` specifies.
+In the case of frame-wise features, besides features, it also saves timestamps in ms
+and the original fps of the video into the same folder with features.
 ```bash
 python main.py \
     feature_type="clip" \

--- a/docs/models/clip.md
+++ b/docs/models/clip.md
@@ -57,7 +57,7 @@ In addition, if you want to use your weights, you need to copy your weights to `
 python main.py \
     feature_type="clip" \
     model_name="ViT-B/32" \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 If you would like to save the features, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the features are saved in `./output/` or where `--output_path` specifies. In the case of frame-wise features, besides features, it also saves timestamps in ms and the original fps of the video into the same folder with features.
@@ -65,7 +65,7 @@ If you would like to save the features, use `--on_extraction save_numpy` (or `sa
 python main.py \
     feature_type="clip" \
     model_name="ViT-B/32" \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     on_extraction=save_numpy \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
@@ -74,7 +74,7 @@ We may increase the extraction speed with batching. Therefore, frame-wise featur
 python main.py \
     feature_type="clip" \
     model_name="ViT-B/32" \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     batch_size=128 \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
@@ -83,7 +83,7 @@ If you would like to extract features at a certain fps, add `--extraction_fps` a
 python main.py \
     feature_type="clip" \
     model_name="ViT-B/32" \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     extraction_fps=5 \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
@@ -96,7 +96,7 @@ The probability that each frame corresponds to all the sentences you provide wil
 python main.py \
     feature_type="clip" \
     model_name="ViT-B/32" \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     extraction_fps=1 \
     show_pred="true" \
     pred_texts="['a dog smiles', 'a woman is lifting']" \

--- a/docs/models/i3d.md
+++ b/docs/models/i3d.md
@@ -3,9 +3,18 @@
   <img src="../../_assets/i3d.png" width="300" />
 </figure>
 
-The _Inflated 3D ([I3D](https://arxiv.org/abs/1705.07750))_ features are extracted using a pre-trained model on [Kinetics 400](https://deepmind.com/research/open-source/kinetics). Here, the features are extracted from the second-to-the-last layer of I3D, before summing them up. Therefore, it outputs two tensors with 1024-d features: for RGB and flow streams. By default, it expects to input 64 RGB and flow frames (`224x224`) which spans 2.56 seconds of the video recorded at 25 fps. In the default case, the features will be of size `Tv x 1024` where `Tv = duration / 2.56`.
+The _Inflated 3D ([I3D](https://arxiv.org/abs/1705.07750))_ features are extracted using
+a pre-trained model on [Kinetics 400](https://deepmind.com/research/open-source/kinetics).
+Here, the features are extracted from the second-to-the-last layer of I3D, before summing them up.
+Therefore, it outputs two tensors with 1024-d features: for RGB and flow streams.
+By default, it expects to input 64 RGB and flow frames (`224x224`) which spans 2.56 seconds of the video recorded at 25 fps.
+In the default case, the features will be of size `Tv x 1024` where `Tv = duration / 2.56`.
 
-Please note, this implementation uses either [PWC-Net](https://arxiv.org/abs/1709.02371) (the default) and [RAFT](https://arxiv.org/abs/2003.12039) optical flow extraction instead of the TV-L1 algorithm, which was used in the original I3D paper as it hampers speed. Yet, it might possibly lead to worse peformance. Our tests show that the performance is reasonable. You may test it yourself by providing `--show_pred` flag.
+Please note, this implementation uses either [PWC-Net](https://arxiv.org/abs/1709.02371) (the default)
+and [RAFT](https://arxiv.org/abs/2003.12039) optical flow extraction instead of the TV-L1 algorithm,
+which was used in the original I3D paper as it hampers speed.
+Yet, it might possibly lead to worse peformance. Our tests show that the performance is reasonable.
+You may test it yourself by providing `--show_pred` flag.
 
 !!! warning "CUDA 11 and GPUs like RTX 3090 and newer"
 
@@ -17,14 +26,16 @@ Please note, this implementation uses either [PWC-Net](https://arxiv.org/abs/170
 
 !!! warning "The PWC-Net does NOT support using CPU currently"
 
-    The PWC-Net uses `cupy` module, which makes it difficult to turn to a version that does not use the GPU. However, if you have solution, you may submit a PR.
+    The PWC-Net uses `cupy` module, which makes it difficult to turn to a version that does not use the GPU.
+    However, if you have solution, you may submit a PR.
 
 ---
 
 ---
 
 ## Set up the Environment for I3D
-Depending on whether you would like to use PWC-Net or RAFT for optical flow extraction, you will need to install separate conda environments – `conda_env_pwc.yml` and `conda_env_torch_zoo`, respectively
+Depending on whether you would like to use PWC-Net or RAFT for optical flow extraction,
+you will need to install separate conda environments – `conda_env_pwc.yml` and `conda_env_torch_zoo`, respectively
 
 ```bash
 # it will create a new conda environment called 'pwc' on your machine
@@ -49,6 +60,7 @@ and extract features from `./sample/v_ZNVhz7ctTq0.mp4` video and show the predic
 ```bash
 python main.py \
     feature_type=i3d \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4]" \
     show_pred=true
 ```
@@ -61,11 +73,12 @@ Activate the environment
 conda activate pwc
 ```
 
-The following will extract I3D features for sample videos using 0th and 2nd devices in parallel. The features are going to be extracted with the default parameters.
+The following will extract I3D features for sample videos.
+The features are going to be extracted with the default parameters.
 ```bash
 python main.py \
     feature_type=i3d \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
@@ -73,19 +86,22 @@ The video paths can be specified as a `.txt` file with paths
 ```bash
 python main.py \
     feature_type=i3d \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
-It is also possible to extract features from either `rgb` or `flow` modalities individually (`--streams`) and, therefore, increasing the speed
+It is also possible to extract features from either `rgb` or `flow` modalities individually (`--streams`)
+and, therefore, increasing the speed
 ```bash
 python main.py \
     feature_type=i3d \
     streams=flow \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
 
-To extract optical flow frames using RAFT approach, specify `--flow_type raft`. Note that using RAFT will make the extraction slower than with PWC-Net yet visual inspection of extracted flow frames suggests that RAFT has a better quality of the estimated flow
+To extract optical flow frames using RAFT approach, specify `--flow_type raft`.
+Note that using RAFT will make the extraction slower than with PWC-Net yet visual inspection of extracted flow
+frames suggests that RAFT has a better quality of the estimated flow
 
 ```bash
 # make sure to activate the correct environment (`torch_zoo`)
@@ -93,15 +109,16 @@ To extract optical flow frames using RAFT approach, specify `--flow_type raft`. 
 python main.py \
     feature_type=i3d \
     flow_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
 
-The features can be saved as numpy arrays by specifying `--on_extraction save_numpy` or `save_pickle`. By default, it will create a folder `./output` and will store features there
+The features can be saved as numpy arrays by specifying `--on_extraction save_numpy` or `save_pickle`.
+By default, it will create a folder `./output` and will store features there
 ```bash
 python main.py \
     feature_type=i3d \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     on_extraction=save_numpy \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
@@ -111,7 +128,7 @@ Also, you may want to try to change I3D window and step sizes
 ```bash
 python main.py \
     feature_type=i3d \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     stack_size=24 \
     step_size=24 \
     file_with_video_paths=./sample/sample_video_paths.txt
@@ -121,15 +138,18 @@ By default, the frames are extracted according to the original fps of a video. I
 ```bash
 python main.py \
     feature_type=i3d \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     extraction_fps=25 \
     stack_size=24 \
     step_size=24 \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
-A fun note, the time span of the I3D features in the last example will match the time span of VGGish features with default parameters (24/25 = 0.96).
+A fun note, the time span of the I3D features in the last example will match the time span of VGGish features
+with default parameters (24/25 = 0.96).
 
-If `--keep_tmp_files` is specified, it keeps them in `--tmp_path` which is `./tmp` by default. Be careful with the `--keep_tmp_files` argument when playing with `--extraction_fps` as it may mess up the frames you extracted before in the same folder.
+If `--keep_tmp_files` is specified, it keeps them in `--tmp_path` which is `./tmp` by default.
+Be careful with the `--keep_tmp_files` argument when playing with `--extraction_fps` as it may mess up the
+frames you extracted before in the same folder.
 
 ---
 

--- a/docs/models/pwc.md
+++ b/docs/models/pwc.md
@@ -34,10 +34,11 @@ Activate the environment
 conda activate pwc
 ```
 
-and extract optical flow from `./sample/v_GGSY1Qvo990.mp4` using one GPU and show the flow for each frame
+and extract optical flow from `./sample/v_GGSY1Qvo990.mp4` and show the flow for each frame
 ```bash
 python main.py \
     feature_type=pwc \
+    device="cuda:0" \
     show_pred=true \
     video_paths="[./sample/v_GGSY1Qvo990.mp4]"
 ```
@@ -47,7 +48,8 @@ To use `show_pred=true`, a screen must be attached to the machine or X11 forward
 ---
 
 ## Examples
-Please see the examples for [`RAFT`](raft.md) optical flow frame extraction. Make sure to replace `--feature_type` argument to `pwc`.
+Please see the examples for [`RAFT`](raft.md) optical flow frame extraction.
+Make sure to replace `--feature_type` argument to `pwc`.
 
 ---
 

--- a/docs/models/r21d.md
+++ b/docs/models/r21d.md
@@ -66,11 +66,12 @@ Start by activating the environment
 conda activate torch_zoo
 ```
 
-It will extract R(2+1)d features for sample videos using 0th and 2nd devices in parallel. The features are going to be extracted with the default parameters.
+It will extract R(2+1)d features for sample videos.
+The features are going to be extracted with the default parameters.
 ```bash
 python main.py \
-    feature_type="r21d" \
-    device_ids="[0, 2]" \
+    feature_type=r21d \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
@@ -78,14 +79,16 @@ Here is an example with `r2plus1d_34_32_ig65m_ft_kinetics` 34-layer R(2+1)D mode
 that waas pre-trained on [IG-65M](https://arxiv.org/abs/1905.00561) and, then, fine-tuned on Kinetics 400
 ```bash
 python main.py \
-    feature_type="r21d" \
+    feature_type=r21d \
     model_name="r2plus1d_34_8_ig65m_ft_kinetics" \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
 
-See [I3D Examples](i3d.md). Note, that this implementation of R(2+1)d only supports the RGB stream.
+See the [config file](https://github.com/v-iashin/video_features/blob/master/configs/r21d.yml) for
+other supported parameters.
+Note, that this implementation of R(2+1)d only supports the RGB stream.
 
 
 

--- a/docs/models/raft.md
+++ b/docs/models/raft.md
@@ -54,37 +54,45 @@ conda activate torch_zoo
 ```
 
 A minimal working example:
-it will extract RAFT optical flow frames for sample videos using 0th and 2nd devices in parallel.
+it will extract RAFT optical flow frames for sample videos.
 ```bash
 python main.py \
     feature_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
-Note, if your videos are quite long, have large dimensions and fps, watch your RAM as the frames are stored in the memory until they are saved. Please see other examples how can you overcome this problem.
+Note, if your videos are quite long, have large dimensions and fps, watch your RAM as the frames are stored
+in the memory until they are saved.
+Please see other examples how can you overcome this problem.
 
-By default, the frames are extracted using the Sintel model. If you wish you can use KITTI-pretrained model by changing the `finetuned_on` argument:
+By default, the frames are extracted using the Sintel model.
+If you wish you can use KITTI-pretrained model by changing the `finetuned_on` argument:
 ```bash
 python main.py \
     feature_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     finetuned_on=kitti \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
 
-If you would like to save the frames, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the frames are saved in `./output/` or where `--output_path` specifies. In the case of RAFT, besides frames, it also saves timestamps in ms and the original fps of the video into the same folder with features.
+If you would like to save the frames, use `--on_extraction save_numpy` (or `save_pickle`) – by default,
+the frames are saved in `./output/` or where `--output_path` specifies.
+In the case of RAFT, besides frames, it also saves timestamps in ms and the original fps of the video into
+the same folder with features.
 ```bash
 python main.py \
     feature_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     on_extraction=save_numpy \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
-Since extracting flow between two frames is cheap we may increase the extraction speed with batching. Therefore, you can use `--batch_size` argument (defaults to `1`) to do so. _A precaution: make sure to properly test the memory impact of using a specific batch size if you are not sure which kind of videos you have. For instance, you tested the extraction on 16:9 aspect ratio videos but some videos are 16:10 which might give you a mem error. Therefore, I would recommend to tune `--batch_size` on a square video and using the resize arguments (showed later)_
+Since extracting flow between two frames is cheap we may increase the extraction speed with batching.
+Therefore, you can use `--batch_size` argument (defaults to `1`) to do so.
+_A precaution: make sure to properly test the memory impact of using a specific batch size if you are not sure which kind of videos you have. For instance, you tested the extraction on 16:9 aspect ratio videos but some videos are 16:10 which might give you a mem error. Therefore, I would recommend to tune `--batch_size` on a square video and using the resize arguments (showed later)_
 ```bash
 python main.py \
     feature_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     batch_size=16 \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
@@ -95,7 +103,7 @@ The latter might be useful when you are not sure which aspect ratio the videos h
 ```bash
 python main.py \
     feature_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     side_size=256 \
     resize_to_smaller_edge=false \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
@@ -104,7 +112,7 @@ If the videos have different fps rate, `--extraction_fps` might be used to speci
 ```bash
 python main.py \
     feature_type=raft \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     extraction_fps=1 \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```

--- a/docs/models/resnet.md
+++ b/docs/models/resnet.md
@@ -49,30 +49,35 @@ Start by activating the environment
 conda activate torch_zoo
 ```
 
-It is pretty much the same procedure as with other features. The example is provided for the ResNet-50 flavour, but we also support ResNet-18,34,101,152.
+It is pretty much the same procedure as with other features.
+The example is provided for the ResNet-50 flavour, but we also support ResNet-18,34,101,152.
 You can specify the model with the `model_name` parameter
 ```bash
 python main.py \
     feature_type=resnet \
     model_name=resnet50 \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
-If you would like to save the features, use `--on_extraction save_numpy` (or `save_pickle`) – by default, the features are saved in `./output/` or where `--output_path` specifies. In the case of frame-wise features, besides features, it also saves timestamps in ms and the original fps of the video into the same folder with features.
+If you would like to save the features, use `--on_extraction save_numpy` (or `save_pickle`) – by default,
+the features are saved in `./output/` or where `--output_path` specifies.
+In the case of frame-wise features, besides features, it also saves timestamps in ms and the original fps of
+the video into the same folder with features.
 ```bash
 python main.py \
     feature_type=resnet \
     model_name=resnet50 \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     on_extraction=save_numpy \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
-Since these features are so fine-grained and light-weight we may increase the extraction speed with batching. Therefore, frame-wise features have `--batch_size` argument, which defaults to `1`.
+Since these features are so fine-grained and light-weight we may increase the extraction speed with batching.
+Therefore, frame-wise features have `--batch_size` argument, which defaults to `1`.
 ```bash
 python main.py \
     feature_type=resnet \
     model_name=resnet50 \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     batch_size=128 \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
@@ -81,7 +86,7 @@ If you would like to extract features at a certain fps, add `--extraction_fps` a
 python main.py \
     feature_type=resnet \
     model_name=resnet50 \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     extraction_fps=5 \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```
@@ -95,4 +100,5 @@ python main.py \
 ---
 
 ## License
-The wrapping code is under MIT, yet, it utilizes `torchvision` library which is under [BSD 3-Clause "New" or "Revised" License](https://github.com/pytorch/vision/blob/master/LICENSE).
+The wrapping code is under MIT, yet, it utilizes `torchvision` library which is
+under [BSD 3-Clause "New" or "Revised" License](https://github.com/pytorch/vision/blob/master/LICENSE).

--- a/docs/models/vggish.md
+++ b/docs/models/vggish.md
@@ -45,14 +45,14 @@ The video paths can be specified as a `.txt` file with paths.
 ```bash
 python main.py \
     feature_type=vggish \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     file_with_video_paths=./sample/sample_video_paths.txt
 ```
 The features can be saved as numpy arrays by specifying `--on_extraction save_numpy` or `save_pickle`. By default, it will create a folder `./output` and will store features there (you can change the output folder using `--output_path`)
 ```bash
 python main.py \
     feature_type=vggish \
-    device_ids="[0, 2]" \
+    device="cuda:0" \
     on_extraction=save_numpy \
     video_paths="[./sample/v_ZNVhz7ctTq0.mp4, ./sample/v_GGSY1Qvo990.mp4]"
 ```

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from omegaconf import OmegaConf
+from tqdm import tqdm
 
 from utils.utils import build_cfg_path, form_list_from_user_input, sanity_check
 
@@ -42,11 +43,11 @@ def main(args_cli):
         raise NotADirectoryError
 
     # unifies whatever a user specified as paths into a list of paths
-    video_paths = form_list_from_user_input(args.video_paths, args.file_with_video_paths)
+    video_paths = form_list_from_user_input(args.video_paths, args.file_with_video_paths, to_shuffle=True)
 
     print(f'The number of specified videos: {len(video_paths)}')
 
-    for video_path in video_paths:
+    for video_path in tqdm(video_paths):
         extractor._extract(video_path)  # note the `_` in the method name
 
     # yep, it is this simple!

--- a/models/_base/base_extractor.py
+++ b/models/_base/base_extractor.py
@@ -1,56 +1,122 @@
-from typing import Union
+import os
+import traceback
+from pathlib import Path
+from typing import Dict, Union
 
-import torch
-from omegaconf import ListConfig
-from tqdm import tqdm
-from utils.utils import action_on_extraction, form_list_from_user_input, is_already_exist
-
-# import traceback
+import numpy as np
+from utils.utils import (load_numpy, load_pickle, make_path, write_numpy,
+                         write_pickle)
 
 
-class BaseExtractor(torch.nn.Module):
+class BaseExtractor(object):
     '''Common things to be inherited by every descendant'''
 
     def __init__(self,
         feature_type: str,
-        video_paths: Union[str, ListConfig],
-        file_with_video_paths: str,
         on_extraction: str,
         tmp_path: str,
         output_path: str,
-        keep_tmp_files: bool
+        keep_tmp_files: bool,
+        device: str,
     ) -> None:
-        super().__init__()
         self.feature_type = feature_type
-        self.path_list = form_list_from_user_input(video_paths, file_with_video_paths)
         self.on_extraction = on_extraction
         self.tmp_path = tmp_path
         self.output_path = output_path
         self.keep_tmp_files = keep_tmp_files
-        self.tqdm_progress = tqdm(total=len(self.path_list))
+        self.device = device
 
-    def forward(self, indices: torch.LongTensor):
+    def _extract(self, video_path: str):
+        '''A wrapper around self.extract. It handles exceptions, checks if files already exist and saves
+        the extracted files if a user desires.
+
+        Args:
+            video_path (str): a video path from which to extract features
+
+        Raises:
+            KeyboardInterrupt: when an error occurs, the script will continue with the rest of the videos.
+                               If a user wants to kill it, ^C (KB interrupt) should be used.
         '''
-        Arguments:
-            indices {torch.LongTensor} -- indices to self.path_list
+        # the try and except structure is used to continue extraction even if after an error (a few bad vids)
+        try:
+            # skips a video path if already exists
+            if not self.is_already_exist(video_path):
+                # extracts features for a video path (this should be implemented by the child modules)
+                feats_dict = self.extract(video_path)
+                # either prints or saves to numpy/pickle
+                self.action_on_extraction(feats_dict, video_path)
+        except KeyboardInterrupt:
+            raise KeyboardInterrupt
+        except:
+            print(f'An error occurred during extraction from: {video_path}:')
+            traceback.print_exc()  # prints the error
+            print('Continuing...')
+
+
+    def action_on_extraction(
+        self,
+        feats_dict: Dict[str, np.ndarray],
+        video_path: str,
+    ) -> None:
+        '''What is going to be done with the extracted features.
+
+        Args:
+            feats_dict (Dict[str, np.ndarray]): A dict with features and possibly some meta. Key will be used as
+                                                suffixes to the saved files if `save_numpy` or `save_pickle` is
+                                                used.
+            video_path (str): A path to the video.
         '''
-        device = indices.device
-        name2module = self.load_model(device)
+        # since the features are enclosed in a dict with another meta information we will iterate on kv
+        action2ext = {'save_numpy': '.npy', 'save_pickle': '.pkl'}
+        action2savefn = {'save_numpy': write_numpy, 'save_pickle': write_pickle}
 
-        for idx in indices:
-            video_path = self.path_list[idx]
-            # when error occurs might fail silently when run from torch data parallel
-            try:
-                # self.output_feat_keys must be defined by the child class that inherits `BaseExtractor`
-                if not is_already_exist(self.output_path, video_path, self.output_feat_keys, self.on_extraction):
-                    feats_dict = self.extract(device, name2module, video_path)
-                    action_on_extraction(feats_dict, video_path, self.output_path, self.on_extraction)
-            except KeyboardInterrupt:
-                raise KeyboardInterrupt
-            except Exception as e:
-                # prints only the last line of an error. Use `traceback.print_exc()` for the whole traceback:
-                # traceback.print_exc()
-                print(e)
-                print(f'Extraction failed at: {video_path} with error (↑). Continuing extraction')
+        for key, value in feats_dict.items():
+            if self.on_extraction == 'print':
+                print(key)
+                print(value)
+                print(f'max: {value.max():.8f}; mean: {value.mean():.8f}; min: {value.min():.8f}')
+                print()
+            elif self.on_extraction in ['save_numpy', 'save_pickle']:
+                # make dir if doesn't exist
+                os.makedirs(self.output_path, exist_ok=True)
+                fpath = make_path(self.output_path, video_path, key, action2ext[self.on_extraction])
+                if key != 'fps' and len(value) == 0:
+                    print(f'Warning: the value is empty for {key} @ {fpath}')
+                # save the info behind the each key
+                action2savefn[self.on_extraction](fpath, value)
+            else:
+                raise NotImplementedError(f'on_extraction: {self.on_extraction} is not implemented')
 
-            self.tqdm_progress.update()
+    def is_already_exist(
+        self,
+        video_path: Union[str, Path],
+    ) -> bool:
+        '''Checks if the all feature files already exist, and also checks if IO does not produce any errors.
+
+        Args:
+            video_path (Union[str, Path]): the path to a video to extract features from
+        '''
+        # if a user does not want to save any features, we need to extract them. 'False' will continue extraction.
+        if self.on_extraction == 'print':
+            return False
+
+        action2ext = {'save_numpy': '.npy', 'save_pickle': '.pkl'}
+        action2loadfn = {'save_numpy': load_numpy, 'save_pickle': load_pickle}
+
+        if self.on_extraction in ['save_numpy', 'save_pickle']:
+            how_many_files_should_exist = len(self.output_feat_keys)
+            how_many_files_exist = 0  # it is a counter
+
+            for key in self.output_feat_keys:
+                fpath = make_path(self.output_path, video_path, key, action2ext[self.on_extraction])
+                if Path(fpath).exists():
+                    action2loadfn[self.on_extraction](fpath)
+                    how_many_files_exist += 1
+                else:
+                    return False
+
+        if how_many_files_exist == how_many_files_should_exist:
+            print(f'Features for {video_path} already exist in {str(Path(fpath).absolute().parent)}/. Skipping..')
+            return True
+        else:
+            return False

--- a/models/_base/base_extractor.py
+++ b/models/_base/base_extractor.py
@@ -122,7 +122,7 @@ class BaseExtractor(object):
                     return False
 
         if how_many_files_exist == how_many_files_should_exist:
-            print(f'Features for {video_path} already exist in {str(Path(fpath).absolute().parent)}/. Skipping..')
+            print(f'Features for {video_path} already exist in {str(Path(fpath).absolute().parent)}/ - skipping..')
             return True
         else:
             return False

--- a/models/_base/base_extractor.py
+++ b/models/_base/base_extractor.py
@@ -70,6 +70,12 @@ class BaseExtractor(object):
         action2ext = {'save_numpy': '.npy', 'save_pickle': '.pkl'}
         action2savefn = {'save_numpy': write_numpy, 'save_pickle': write_pickle}
 
+        # playing safe: the second check if files already exist and openable before possibly overwritting them
+        if self.on_extraction in ['save_numpy', 'save_pickle'] and self.is_already_exist(video_path):
+            # it is ok to ignore this warning
+            print(f'WARNING: extraction didnt find feature files on the 1st try but did on the 2nd try.')
+            return
+
         for key, value in feats_dict.items():
             if self.on_extraction == 'print':
                 print(key)

--- a/models/pwc/extract_pwc.py
+++ b/models/pwc/extract_pwc.py
@@ -13,12 +13,11 @@ class ExtractPWC(BaseOpticalFlowExtractor):
     def __init__(self, args: omegaconf.DictConfig) -> None:
         super().__init__(
             feature_type=args.feature_type,
-            video_paths=args.video_paths,
-            file_with_video_paths=args.file_with_video_paths,
             on_extraction=args.on_extraction,
             tmp_path=args.tmp_path,
             output_path=args.output_path,
             keep_tmp_files=args.keep_tmp_files,
+            device=args.device,
             ckpt_path=DATASET_to_PWC_CKPT_PATHS['sintel'],
             batch_size=args.batch_size,
             resize_to_smaller_edge=args.resize_to_smaller_edge,

--- a/models/raft/extract_raft.py
+++ b/models/raft/extract_raft.py
@@ -14,12 +14,11 @@ class ExtractRAFT(BaseOpticalFlowExtractor):
     def __init__(self, args: omegaconf.DictConfig) -> None:
         super().__init__(
             feature_type=args.feature_type,
-            video_paths=args.video_paths,
-            file_with_video_paths=args.file_with_video_paths,
             on_extraction=args.on_extraction,
             tmp_path=args.tmp_path,
             output_path=args.output_path,
             keep_tmp_files=args.keep_tmp_files,
+            device=args.device,
             ckpt_path=DATASET_to_RAFT_CKPT_PATHS[args.finetuned_on],
             batch_size=args.batch_size,
             resize_to_smaller_edge=args.resize_to_smaller_edge,

--- a/tests/clip/test_clip.py
+++ b/tests/clip/test_clip.py
@@ -19,23 +19,24 @@ TO_MAKE_REF = False
 
 signature = 'device, video_paths, model_name, batch_size, extraction_fps, to_make_ref'
 test_params = [
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/32', 1, None, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/32', 128, None, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/32', 1, 5, TO_MAKE_REF),
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/16', 1, None, TO_MAKE_REF),
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'RN50x16', 1, None, TO_MAKE_REF),
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'RN50x4', 1, None, TO_MAKE_REF),
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'RN101', 1, None, TO_MAKE_REF),
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'RN50', 1, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/32', 1, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/32', 128, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/32', 1, 5, TO_MAKE_REF),
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'ViT-B/16', 1, None, TO_MAKE_REF),
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'RN50x16', 1, None, TO_MAKE_REF),
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'RN50x4', 1, None, TO_MAKE_REF),
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'RN101', 1, None, TO_MAKE_REF),
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'RN50', 1, None, TO_MAKE_REF),
 ]
 
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, model_name, batch_size, extraction_fps, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
         model_name=model_name,
         batch_size=batch_size,
         extraction_fps=extraction_fps
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/tests/i3d/test_i3d.py
+++ b/tests/i3d/test_i3d.py
@@ -22,23 +22,24 @@ TO_MAKE_REF = False
 signature = 'device, video_paths, streams, flow_type, stack_size, step_size, extraction_fps, to_make_ref'
 if '/pwc/' in sys.executable:
     test_params = [
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', None, 'pwc', None, None, None, TO_MAKE_REF),
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', None, 'pwc', 24, 24, 25, TO_MAKE_REF),
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', 'rgb', 'pwc', None, None, None, TO_MAKE_REF),
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', 'flow', 'pwc', None, None, None, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', None, 'pwc', None, None, None, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', None, 'pwc', 24, 24, 25, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'rgb', 'pwc', None, None, None, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'flow', 'pwc', None, None, None, TO_MAKE_REF),
     ]
 else:
     test_params = [
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', None, 'raft', None, None, None, TO_MAKE_REF),
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', None, 'raft', 24, 24, 25, TO_MAKE_REF),
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', 'rgb', 'raft', None, None, None, TO_MAKE_REF),
-        ('cuda', './sample/v_GGSY1Qvo990.mp4', 'flow', 'raft', None, None, None, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', None, 'raft', None, None, None, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', None, 'raft', 24, 24, 25, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'rgb', 'raft', None, None, None, TO_MAKE_REF),
+        ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'flow', 'raft', None, None, None, TO_MAKE_REF),
     ]
 
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, streams, flow_type, stack_size, step_size, extraction_fps, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
         streams=streams,
         flow_type=flow_type,
@@ -46,4 +47,4 @@ def test(device, video_paths, streams, flow_type, stack_size, step_size, extract
         step_size=step_size,
         extraction_fps=extraction_fps
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/tests/pwc/test_pwc.py
+++ b/tests/pwc/test_pwc.py
@@ -24,17 +24,18 @@ TO_MAKE_REF = False
 
 signature = 'device, video_paths, side_size, extraction_fps, to_make_ref'
 test_params = [
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', None, None, TO_MAKE_REF),  # 559M
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 112, 3, TO_MAKE_REF),  # 18M
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 384, 5, TO_MAKE_REF),  # 345M
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', None, None, TO_MAKE_REF),  # 559M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 112, 3, TO_MAKE_REF),  # 18M
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 384, 5, TO_MAKE_REF),  # 345M
 ]
 
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, side_size, extraction_fps, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
         side_size=side_size,
         extraction_fps=extraction_fps
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/tests/r21d/test_r21d.py
+++ b/tests/r21d/test_r21d.py
@@ -20,19 +20,20 @@ TO_MAKE_REF = False
 
 signature = 'device, video_paths, model_name, stack_size, step_size, extraction_fps, to_make_ref'
 test_params = [
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_18_16_kinetics', None, None, None, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_32_ig65m_ft_kinetics', None, None, None, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, None, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, 1, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_18_16_kinetics', None, None, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_32_ig65m_ft_kinetics', None, None, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, 1, TO_MAKE_REF),
 ]
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, model_name, stack_size, step_size, extraction_fps, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
         model_name=model_name,
         stack_size=stack_size,
         step_size=step_size,
         extraction_fps=extraction_fps
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/tests/raft/test_raft.py
+++ b/tests/raft/test_raft.py
@@ -20,19 +20,20 @@ TO_MAKE_REF = False
 
 signature = 'device, video_paths, finetuned_on, batch_size, side_size, resize_to_smaller_edge, extraction_fps, to_make_ref'
 test_params = [
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, None, True, None, TO_MAKE_REF), # 500MB+
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, None, True, None, TO_MAKE_REF), # 500MB+
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, None, True, None, TO_MAKE_REF), # 500MB+
-    # ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, None, TO_MAKE_REF), # 500MB+
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, None, True, 1, TO_MAKE_REF), # 26M
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, 256, True, 1, TO_MAKE_REF), # 26M
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, 256, False, 1, TO_MAKE_REF), # 17M
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, 1, TO_MAKE_REF), # 17M
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, None, True, None, TO_MAKE_REF), # 500MB+
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, None, True, None, TO_MAKE_REF), # 500MB+
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, None, True, None, TO_MAKE_REF), # 500MB+
+    # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, None, TO_MAKE_REF), # 500MB+
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, None, True, 1, TO_MAKE_REF), # 26M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, 256, True, 1, TO_MAKE_REF), # 26M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, 256, False, 1, TO_MAKE_REF), # 17M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, 1, TO_MAKE_REF), # 17M
 ]
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, finetuned_on, batch_size, side_size, resize_to_smaller_edge, extraction_fps, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
         finetuned_on=finetuned_on,
         batch_size=batch_size,
@@ -40,4 +41,4 @@ def test(device, video_paths, finetuned_on, batch_size, side_size, resize_to_sma
         resize_to_smaller_edge=resize_to_smaller_edge,
         extraction_fps=extraction_fps
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/tests/resnet/test_resnet.py
+++ b/tests/resnet/test_resnet.py
@@ -21,17 +21,18 @@ TO_MAKE_REF = False
 
 signature = 'device, video_paths, model_name, batch_size, extraction_fps, to_make_ref'
 test_params = [
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'resnet101', 1, 1, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'resnet50', 1, None, TO_MAKE_REF),
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', 'resnet34', 64, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'resnet101', 1, 1, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'resnet50', 1, None, TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'resnet34', 64, None, TO_MAKE_REF),
 ]
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, model_name, batch_size, extraction_fps, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
         model_name=model_name,
         batch_size=batch_size,
         extraction_fps=extraction_fps
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/tests/vggish/test_vggish.py
+++ b/tests/vggish/test_vggish.py
@@ -20,12 +20,13 @@ TO_MAKE_REF = False
 
 signature = 'device, video_paths, to_make_ref'
 test_params = [
-    ('cuda', './sample/v_GGSY1Qvo990.mp4', TO_MAKE_REF),
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', TO_MAKE_REF),
 ]
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, to_make_ref):
     # get config
     patch_kwargs = dict(
+        device=device,
         video_paths=video_paths,
     )
-    base_test_script(FEATURE_TYPE, Extractor, device, to_make_ref, **patch_kwargs)
+    base_test_script(FEATURE_TYPE, Extractor, to_make_ref, **patch_kwargs)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -55,38 +55,6 @@ def make_path(output_root, video_path, output_key, ext):
     # construct the paths to save the features
     return os.path.join(output_root, fname)
 
-def action_on_extraction(feats_dict: Dict[str, np.ndarray], video_path, output_path, on_extraction: str):
-    '''What is going to be done with the extracted features.
-
-    Args:
-        feats_dict (Dict[str, np.ndarray]): A dict with features and possibly some meta. Key will be used as
-                                            suffixes to the saved files if `save_numpy` or `save_pickle` is
-                                            used.
-        video_path (str): A path to the video.
-        on_extraction (str): What to do with the features on extraction.
-        output_path (str): Where to save the features if `save_numpy` or `save_pickle` is used.
-    '''
-    # since the features are enclosed in a dict with another meta information we will iterate on kv
-    action2ext = {'save_numpy': '.npy', 'save_pickle': '.pkl'}
-    action2savefn = {'save_numpy': write_numpy, 'save_pickle': write_pickle}
-
-    for key, value in feats_dict.items():
-        if on_extraction == 'print':
-            print(key)
-            print(value)
-            print(f'max: {value.max():.8f}; mean: {value.mean():.8f}; min: {value.min():.8f}')
-            print()
-        elif on_extraction in ['save_numpy', 'save_pickle']:
-            # make dir if doesn't exist
-            os.makedirs(output_path, exist_ok=True)
-            fpath = make_path(output_path, video_path, key, action2ext[on_extraction])
-            if key != 'fps' and len(value) == 0:
-                print(f'Warning: the value is empty for {key} @ {fpath}')
-            # save the info behind the each key
-            action2savefn[on_extraction](fpath, value)
-        else:
-            raise NotImplementedError(f'on_extraction: {on_extraction} is not implemented')
-
 def form_slices(size: int, stack_size: int, step_size: int) -> list((int, int)):
     '''print(form_slices(100, 15, 15) - example'''
     slices = []
@@ -105,14 +73,15 @@ def sanity_check(args: Union[argparse.Namespace, DictConfig]):
     Args:
         args (Union[argparse.Namespace, DictConfig]): Parsed user arguments
     '''
+
+    if 'cuda' in args.device and not torch.cuda.is_available():
+        print(f'A GPU was attempted to use but the system does not have one. Going to use CPU...')
+        args.device = 'cpu'
     assert args.file_with_video_paths or args.video_paths, '`video_paths` or `file_with_video_paths` must be specified'
     filenames = [Path(p).stem for p in form_list_from_user_input(args.video_paths, args.file_with_video_paths)]
     assert len(filenames) == len(set(filenames)), 'Non-unique filenames. See video_features/issues/54'
     assert os.path.relpath(args.output_path) != os.path.relpath(args.tmp_path), 'The same path for out & tmp'
     if args.show_pred:
-        if not args.cpu:
-            print('You want to see predictions. So, I will use only the first GPU from the list you specified.')
-            args.device_ids = [args.device_ids[0]]
         if args.feature_type == 'vggish':
             print('Showing class predictions is not implemented for VGGish')
     # if args.feature_type == 'r21d':
@@ -127,8 +96,6 @@ def sanity_check(args: Union[argparse.Namespace, DictConfig]):
             print('If you want to keep frames while extracting features, please create an issue')
     if args.feature_type == 'pwc' or (args.feature_type == 'i3d' and args.flow_type == 'pwc'):
         assert not args.cpu, 'PWC does NOT support using CPU'
-    if isinstance(args.device_ids, int):
-        args.device_ids = [args.device_ids]
     if 'batch_size' in args:
         assert args.batch_size is not None, f'Please specify `batch_size`. It is {args.batch_size} now'
 
@@ -291,42 +258,3 @@ def load_pickle(fpath):
 
 def write_pickle(fpath, value):
     return pickle.dump(value, open(fpath, 'wb'))
-
-def is_already_exist(
-        output_path: Union[str, Path],
-        video_path: Union[str, Path],
-        output_feat_keys: List[str],
-        on_extraction: str,
-    ) -> bool:
-    '''Checks if the all feature files already exist, and also checks if IO does not produce any errors.
-
-    Args:
-        output_path (Union[str, Path]): root folder to output features to
-        video_path (Union[str, Path]): the path to a video to extract features from
-        output_feat_keys (List[str]): the feature file keys (e.g. 'feature_type', 'fps', and 'timestamp_ms')
-        on_extraction (str): action on extraction such as 'save_numpy' or 'print'
-    '''
-    # if a user does not want to save any features, we need to extract them. 'False' will continue extraction.
-    if on_extraction == 'print':
-        return False
-
-    action2ext = {'save_numpy': '.npy', 'save_pickle': '.pkl'}
-    action2loadfn = {'save_numpy': load_numpy, 'save_pickle': load_pickle}
-
-    if on_extraction in ['save_numpy', 'save_pickle']:
-        how_many_files_should_exist = len(output_feat_keys)
-        how_many_files_exist = 0  # it is a counter
-
-        for key in output_feat_keys:
-            fpath = make_path(output_path, video_path, key, action2ext[on_extraction])
-            if Path(fpath).exists():
-                action2loadfn[on_extraction](fpath)
-                how_many_files_exist += 1
-            else:
-                return False
-
-    if how_many_files_exist == how_many_files_should_exist:
-        print(f'Features for {video_path} already exist in {str(Path(fpath).absolute().parent)}/. Skipping..')
-        return True
-    else:
-        return False

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -74,7 +74,13 @@ def sanity_check(args: Union[argparse.Namespace, DictConfig]):
     Args:
         args (Union[argparse.Namespace, DictConfig]): Parsed user arguments
     '''
-
+    if 'device_ids' in args:
+        print('WARNING:')
+        print('Running feature extraction on multiple devices in a _single_ process is no longer supported.')
+        print('To use several GPUs, you simply need to start the extraction with another GPU ordinal.')
+        print('For instance, in one terminal: `device="cuda:0"` and `device="cuda:1"` in the second, etc.')
+        print(f'Your device specification (device_ids={args.device_ids}) is converted to `device="cuda:0"`.')
+        args.device = 'cuda:0'
     if 'cuda' in args.device and not torch.cuda.is_available():
         print(f'A GPU was attempted to use but the system does not have one. Going to use CPU...')
         args.device = 'cpu'


### PR DESCRIPTION
As outlined in #63, with this PR we drop the unnecessary complexity introduced by `torch.DataParallel` primitives. I want to make it plain and easy to debug. 

The multi-GPU parallelism can be easily achieved by spawning several terminals and running the same command with different devices. 

This means that if you have a cluster at your disposal, you may create an array job running the same command with the same output and input folders. It will start slow but shortly will start to discover features that already exist (#62).

- [x] do you randomize the file list?
- [x] do you make sure that no "writing collision by different workers" will emerge?
  - added another check in `BaseExtractor.action_on_extraction()` hoping not to introduce a significant reduction in the speed, especially for optical flow as those can be quite big.
- [x] address the todos in #63.
- [x] check the reduction in speed with and without the second check for existence.
  - I did not notice any difference on RAFT extraction on 3 x 2080Ti on 190 UCF101 videos (flow is in 90-500MB files)
- [x] check a multi-gpu setup
- [x] manual check with MWEs
- [ ] colab 