### PR TITLE
PEP-style formatting fixes

### DIFF
--- a/models/_base/base_extractor.py
+++ b/models/_base/base_extractor.py
@@ -9,16 +9,16 @@ from utils.utils import (load_numpy, load_pickle, make_path, write_numpy,
 
 
 class BaseExtractor(object):
-    '''Common things to be inherited by every descendant'''
+    """Common things to be inherited by every descendant"""
 
     def __init__(self,
-        feature_type: str,
-        on_extraction: str,
-        tmp_path: str,
-        output_path: str,
-        keep_tmp_files: bool,
-        device: str,
-    ) -> None:
+                 feature_type: str,
+                 on_extraction: str,
+                 tmp_path: str,
+                 output_path: str,
+                 keep_tmp_files: bool,
+                 device: str,
+                 ) -> None:
         self.feature_type = feature_type
         self.on_extraction = on_extraction
         self.tmp_path = tmp_path
@@ -27,7 +27,7 @@ class BaseExtractor(object):
         self.device = device
 
     def _extract(self, video_path: str):
-        '''A wrapper around self.extract. It handles exceptions, checks if files already exist and saves
+        """A wrapper around self.extract. It handles exceptions, checks if files already exist and saves
         the extracted files if a user desires.
 
         Args:
@@ -36,7 +36,7 @@ class BaseExtractor(object):
         Raises:
             KeyboardInterrupt: when an error occurs, the script will continue with the rest of the videos.
                                If a user wants to kill it, ^C (KB interrupt) should be used.
-        '''
+        """
         # the try and except structure is used to continue extraction even if after an error (a few bad vids)
         try:
             # skips a video path if already exists
@@ -52,20 +52,19 @@ class BaseExtractor(object):
             traceback.print_exc()  # prints the error
             print('Continuing...')
 
-
     def action_on_extraction(
-        self,
-        feats_dict: Dict[str, np.ndarray],
-        video_path: str,
+            self,
+            feats_dict: Dict[str, np.ndarray],
+            video_path: str,
     ) -> None:
-        '''What is going to be done with the extracted features.
+        """What is going to be done with the extracted features.
 
         Args:
             feats_dict (Dict[str, np.ndarray]): A dict with features and possibly some meta. Key will be used as
                                                 suffixes to the saved files if `save_numpy` or `save_pickle` is
                                                 used.
             video_path (str): A path to the video.
-        '''
+        """
         # since the features are enclosed in a dict with another meta information we will iterate on kv
         action2ext = {'save_numpy': '.npy', 'save_pickle': '.pkl'}
         action2savefn = {'save_numpy': write_numpy, 'save_pickle': write_pickle}
@@ -94,14 +93,14 @@ class BaseExtractor(object):
                 raise NotImplementedError(f'on_extraction: {self.on_extraction} is not implemented')
 
     def is_already_exist(
-        self,
-        video_path: Union[str, Path],
+            self,
+            video_path: Union[str, Path],
     ) -> bool:
-        '''Checks if the all feature files already exist, and also checks if IO does not produce any errors.
+        """Checks if the all feature files already exist, and also checks if IO does not produce any errors.
 
         Args:
             video_path (Union[str, Path]): the path to a video to extract features from
-        '''
+        """
         # if a user does not want to save any features, we need to extract them. 'False' will continue extraction.
         if self.on_extraction == 'print':
             return False

--- a/models/_base/base_flow_extractor.py
+++ b/models/_base/base_flow_extractor.py
@@ -14,24 +14,24 @@ from utils.utils import dp_state_to_normal, reencode_video_with_diff_fps
 
 
 class BaseOpticalFlowExtractor(BaseExtractor):
-    '''Common things for all frame-wise extractors (such as RAFT and PWC).'''
+    """Common things for all frame-wise extractors (such as RAFT and PWC)."""
 
     def __init__(self,
-        # BaseExtractor arguments
-        feature_type: str,
-        on_extraction: str,
-        tmp_path: str,
-        output_path: str,
-        keep_tmp_files: bool,
-        device: str,
-        # This class
-        ckpt_path: str,
-        batch_size: int,
-        resize_to_smaller_edge: bool,
-        side_size: Union[None, int],
-        extraction_fps: Union[None, int],
-        show_pred: bool,
-    ) -> None:
+                 # BaseExtractor arguments
+                 feature_type: str,
+                 on_extraction: str,
+                 tmp_path: str,
+                 output_path: str,
+                 keep_tmp_files: bool,
+                 device: str,
+                 # This class
+                 ckpt_path: str,
+                 batch_size: int,
+                 resize_to_smaller_edge: bool,
+                 side_size: Union[None, int],
+                 extraction_fps: Union[None, int],
+                 show_pred: bool,
+                 ) -> None:
         # init the BaseExtractor
         super().__init__(
             feature_type=feature_type,
@@ -55,21 +55,21 @@ class BaseOpticalFlowExtractor(BaseExtractor):
             ])
         else:
             self.transforms = torchvision.transforms.Compose([ToTensorWithoutScaling()])
-        self.extraction_fps = extraction_fps # use `None` to skip reencoding and keep the original video fps
+        self.extraction_fps = extraction_fps  # use `None` to skip reencoding and keep the original video fps
         self.output_feat_keys = [self.feature_type, 'fps', 'timestamps_ms']
         self.show_pred = show_pred
         self.name2module = self.load_model()
 
     @torch.no_grad()
     def extract(self, video_path: str) -> Dict[str, np.ndarray]:
-        '''Extracts features for a given video path.
+        """Extracts features for a given video path.
 
         Arguments:
             video_path (str): a video path from which to extract features
 
         Returns:
             Dict[str, np.ndarray]: 'features_name', 'fps', 'timestamps_ms'
-        '''
+        """
 
         # take the video, change fps and save to the tmp folder
         if self.extraction_fps is not None:
@@ -146,13 +146,12 @@ class BaseOpticalFlowExtractor(BaseExtractor):
         self.maybe_show_pred(batch_feats, batch)
         return batch_feats
 
-
     def load_model(self) -> torch.nn.Module:
-        '''Defines the models, loads checkpoints, sends them to the device.
+        """Defines the models, loads checkpoints, sends them to the device.
 
         Returns:
             torch.nn.Module: flow extraction module.
-        '''
+        """
         if self.feature_type == 'raft':
             model = RAFT()
         elif self.feature_type == 'pwc':
@@ -169,13 +168,13 @@ class BaseOpticalFlowExtractor(BaseExtractor):
         return {'model': model}
 
     def maybe_show_pred(self, batch_feats: torch.Tensor, batch: torch.Tensor):
-        '''Shows the resulting flow frames and a corrsponding RGB frame (the 1st of the two) in a cv2 window.
+        """Shows the resulting flow frames and a corrsponding RGB frame (the 1st of the two) in a cv2 window.
 
         Args:
             batch_feats (torch.Tensor): the output of the model
             batch (torch.Tensor): the stack of rgb inputs
             device (torch.device, optional): _description_. Defaults to None.
-        '''
+        """
         if self.show_pred:
             for idx, flow in enumerate(batch_feats):
                 img = batch[idx].permute(1, 2, 0).cpu().numpy()

--- a/models/_base/base_framewise_extractor.py
+++ b/models/_base/base_framewise_extractor.py
@@ -9,23 +9,23 @@ from utils.utils import reencode_video_with_diff_fps
 
 
 class BaseFrameWiseExtractor(BaseExtractor):
-    '''Common things for all frame-wise extractors (such as ResNet or CLIP).
-    However, optical flow has another parent class: OpticalFlowExtractor'''
+    """Common things for all frame-wise extractors (such as ResNet or CLIP).
+    However, optical flow has another parent class: OpticalFlowExtractor"""
 
     def __init__(self,
-        # BaseExtractor arguments
-        feature_type: str,
-        on_extraction: str,
-        tmp_path: str,
-        output_path: str,
-        keep_tmp_files: bool,
-        device: str,
-        # This class
-        model_name: str,
-        batch_size: int,
-        extraction_fps: Union[None, int],
-        show_pred: bool,
-    ) -> None:
+                 # BaseExtractor arguments
+                 feature_type: str,
+                 on_extraction: str,
+                 tmp_path: str,
+                 output_path: str,
+                 keep_tmp_files: bool,
+                 device: str,
+                 # This class
+                 model_name: str,
+                 batch_size: int,
+                 extraction_fps: Union[None, int],
+                 show_pred: bool,
+                 ) -> None:
         # init the BaseExtractor
         super().__init__(
             feature_type=feature_type,
@@ -38,20 +38,20 @@ class BaseFrameWiseExtractor(BaseExtractor):
         # (Re-)Define arguments for this class
         self.model_name = model_name
         self.batch_size = batch_size
-        self.extraction_fps = extraction_fps # use `None` to skip reencoding and keep the original video fps
+        self.extraction_fps = extraction_fps  # use `None` to skip reencoding and keep the original video fps
         self.output_feat_keys = [self.feature_type, 'fps', 'timestamps_ms']
         self.show_pred = show_pred
 
     @torch.no_grad()
     def extract(self, video_path: str) -> Dict[str, np.ndarray]:
-        '''Extracts features for a given video path.
+        """Extracts features for a given video path.
 
         Arguments:
             video_path (str): a video path from which to extract features
 
         Returns:
             Dict[str, np.ndarray]: 'features_name', 'fps', 'timestamps_ms'
-        '''
+        """
         # take the video, change fps and save to the tmp folder
         if self.extraction_fps is not None:
             video_path = reencode_video_with_diff_fps(video_path, self.tmp_path, self.extraction_fps)

--- a/models/clip/clip_src/clip.py
+++ b/models/clip/clip_src/clip.py
@@ -1,9 +1,9 @@
-'''
+"""
     Reference: https://github.com/openai/CLIP/tree/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1
     Modified by Kamino (@Kamino666):
       - fix: fix the error when loading custom non-jit weights
       - change: remove packaging check since our repo meets the requirements
-'''
+"""
 
 import hashlib
 import os

--- a/models/clip/extract_clip.py
+++ b/models/clip/extract_clip.py
@@ -39,9 +39,8 @@ class ExtractCLIP(BaseFrameWiseExtractor):
             self.pred_texts_tok = clip.tokenize(self.pred_texts).long()
         self.name2module = self.load_model()
 
-
     def load_model(self) -> Dict[str, torch.nn.Module]:
-        '''Defines the models, loads checkpoints, sends them to the device.
+        """Defines the models, loads checkpoints, sends them to the device.
         For CLIP, it also sets the appropriate transforms
 
         Raises:
@@ -49,7 +48,7 @@ class ExtractCLIP(BaseFrameWiseExtractor):
 
         Returns:
             Dict[str, torch.nn.Module]: model-agnostic dict holding modules for extraction and show_pred
-        '''
+        """
         if self.model_name in clip.available_models():
             model_path = self.model_name
         elif self.model_name == 'custom':

--- a/models/r21d/extract_r21d.py
+++ b/models/r21d/extract_r21d.py
@@ -59,14 +59,14 @@ class ExtractR21D(BaseExtractor):
 
     @torch.no_grad()
     def extract(self, video_path: str) -> Dict[str, np.ndarray]:
-        '''Extracts features for a given video path.
+        """Extracts features for a given video path.
 
         Arguments:
             video_path (str): a video path from which to extract features
 
         Returns:
             Dict[str, np.ndarray]: feature name (e.g. 'fps' or feature_type) to the feature tensor
-        '''
+        """
         # take the video, change fps and save to the tmp folder
         if self.extraction_fps is not None:
             video_path = reencode_video_with_diff_fps(video_path, self.tmp_path, self.extraction_fps)
@@ -94,14 +94,14 @@ class ExtractR21D(BaseExtractor):
         return feats_dict
 
     def load_model(self) -> Dict[str, torch.nn.Module]:
-        '''Defines the models, loads checkpoints, sends them to the device.
+        """Defines the models, loads checkpoints, sends them to the device.
 
         Raises:
             NotImplementedError: if a model is not implemented.
 
         Returns:
             Dict[str, torch.nn.Module]: model-agnostic dict holding modules for extraction and show_pred
-        '''
+        """
         if self.model_name == 'r2plus1d_18_16_kinetics':
             model = torchvision.models.video.r2plus1d_18(pretrained=True)
         else:

--- a/models/raft/raft_src/corr.py
+++ b/models/raft/raft_src/corr.py
@@ -19,10 +19,10 @@ class CorrBlock:
         corr = CorrBlock.corr(fmap1, fmap2)
 
         batch, h1, w1, dim, h2, w2 = corr.shape
-        corr = corr.reshape(batch*h1*w1, dim, h2, w2)
+        corr = corr.reshape(batch * h1 * w1, dim, h2, w2)
 
         self.corr_pyramid.append(corr)
-        for i in range(self.num_levels-1):
+        for i in range(self.num_levels - 1):
             corr = F.avg_pool2d(corr, 2, stride=2)
             self.corr_pyramid.append(corr)
 
@@ -34,12 +34,12 @@ class CorrBlock:
         out_pyramid = []
         for i in range(self.num_levels):
             corr = self.corr_pyramid[i]
-            dx = torch.linspace(-r, r, 2*r+1)
-            dy = torch.linspace(-r, r, 2*r+1)
+            dx = torch.linspace(-r, r, 2 * r + 1)
+            dy = torch.linspace(-r, r, 2 * r + 1)
             delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(coords.device)
 
-            centroid_lvl = coords.reshape(batch*h1*w1, 1, 1, 2) / 2**i
-            delta_lvl = delta.view(1, 2*r+1, 2*r+1, 2)
+            centroid_lvl = coords.reshape(batch * h1 * w1, 1, 1, 2) / 2 ** i
+            delta_lvl = delta.view(1, 2 * r + 1, 2 * r + 1, 2)
             coords_lvl = centroid_lvl + delta_lvl
 
             corr = bilinear_sampler(corr, coords_lvl)
@@ -52,12 +52,12 @@ class CorrBlock:
     @staticmethod
     def corr(fmap1, fmap2):
         batch, dim, ht, wd = fmap1.shape
-        fmap1 = fmap1.view(batch, dim, ht*wd)
-        fmap2 = fmap2.view(batch, dim, ht*wd)
+        fmap1 = fmap1.view(batch, dim, ht * wd)
+        fmap2 = fmap2.view(batch, dim, ht * wd)
 
-        corr = torch.matmul(fmap1.transpose(1,2), fmap2)
+        corr = torch.matmul(fmap1.transpose(1, 2), fmap2)
         corr = corr.view(batch, ht, wd, 1, ht, wd)
-        return corr  / torch.sqrt(torch.tensor(dim).float())
+        return corr / torch.sqrt(torch.tensor(dim).float())
 
 
 class AlternateCorrBlock:
@@ -82,7 +82,7 @@ class AlternateCorrBlock:
             fmap1_i = self.pyramid[0][0].permute(0, 2, 3, 1).contiguous()
             fmap2_i = self.pyramid[i][1].permute(0, 2, 3, 1).contiguous()
 
-            coords_i = (coords / 2**i).reshape(B, 1, H, W, 2).contiguous()
+            coords_i = (coords / 2 ** i).reshape(B, 1, H, W, 2).contiguous()
             corr, = alt_cuda_corr.forward(fmap1_i, fmap2_i, coords_i, r)
             corr_list.append(corr.squeeze(1))
 

--- a/models/raft/raft_src/extractor.py
+++ b/models/raft/raft_src/extractor.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 class ResidualBlock(nn.Module):
     def __init__(self, in_planes, planes, norm_fn='group', stride=1):
         super(ResidualBlock, self).__init__()
-  
+
         self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=3, padding=1, stride=stride)
         self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, padding=1)
         self.relu = nn.ReLU(inplace=True)
@@ -18,13 +18,13 @@ class ResidualBlock(nn.Module):
             self.norm2 = nn.GroupNorm(num_groups=num_groups, num_channels=planes)
             if not stride == 1:
                 self.norm3 = nn.GroupNorm(num_groups=num_groups, num_channels=planes)
-        
+
         elif norm_fn == 'batch':
             self.norm1 = nn.BatchNorm2d(planes)
             self.norm2 = nn.BatchNorm2d(planes)
             if not stride == 1:
                 self.norm3 = nn.BatchNorm2d(planes)
-        
+
         elif norm_fn == 'instance':
             self.norm1 = nn.InstanceNorm2d(planes)
             self.norm2 = nn.InstanceNorm2d(planes)
@@ -39,11 +39,10 @@ class ResidualBlock(nn.Module):
 
         if stride == 1:
             self.downsample = None
-        
-        else:    
+
+        else:
             self.downsample = nn.Sequential(
                 nn.Conv2d(in_planes, planes, kernel_size=1, stride=stride), self.norm3)
-
 
     def forward(self, x):
         y = x
@@ -53,38 +52,37 @@ class ResidualBlock(nn.Module):
         if self.downsample is not None:
             x = self.downsample(x)
 
-        return self.relu(x+y)
-
+        return self.relu(x + y)
 
 
 class BottleneckBlock(nn.Module):
     def __init__(self, in_planes, planes, norm_fn='group', stride=1):
         super(BottleneckBlock, self).__init__()
-  
-        self.conv1 = nn.Conv2d(in_planes, planes//4, kernel_size=1, padding=0)
-        self.conv2 = nn.Conv2d(planes//4, planes//4, kernel_size=3, padding=1, stride=stride)
-        self.conv3 = nn.Conv2d(planes//4, planes, kernel_size=1, padding=0)
+
+        self.conv1 = nn.Conv2d(in_planes, planes // 4, kernel_size=1, padding=0)
+        self.conv2 = nn.Conv2d(planes // 4, planes // 4, kernel_size=3, padding=1, stride=stride)
+        self.conv3 = nn.Conv2d(planes // 4, planes, kernel_size=1, padding=0)
         self.relu = nn.ReLU(inplace=True)
 
         num_groups = planes // 8
 
         if norm_fn == 'group':
-            self.norm1 = nn.GroupNorm(num_groups=num_groups, num_channels=planes//4)
-            self.norm2 = nn.GroupNorm(num_groups=num_groups, num_channels=planes//4)
+            self.norm1 = nn.GroupNorm(num_groups=num_groups, num_channels=planes // 4)
+            self.norm2 = nn.GroupNorm(num_groups=num_groups, num_channels=planes // 4)
             self.norm3 = nn.GroupNorm(num_groups=num_groups, num_channels=planes)
             if not stride == 1:
                 self.norm4 = nn.GroupNorm(num_groups=num_groups, num_channels=planes)
-        
+
         elif norm_fn == 'batch':
-            self.norm1 = nn.BatchNorm2d(planes//4)
-            self.norm2 = nn.BatchNorm2d(planes//4)
+            self.norm1 = nn.BatchNorm2d(planes // 4)
+            self.norm2 = nn.BatchNorm2d(planes // 4)
             self.norm3 = nn.BatchNorm2d(planes)
             if not stride == 1:
                 self.norm4 = nn.BatchNorm2d(planes)
-        
+
         elif norm_fn == 'instance':
-            self.norm1 = nn.InstanceNorm2d(planes//4)
-            self.norm2 = nn.InstanceNorm2d(planes//4)
+            self.norm1 = nn.InstanceNorm2d(planes // 4)
+            self.norm2 = nn.InstanceNorm2d(planes // 4)
             self.norm3 = nn.InstanceNorm2d(planes)
             if not stride == 1:
                 self.norm4 = nn.InstanceNorm2d(planes)
@@ -98,11 +96,10 @@ class BottleneckBlock(nn.Module):
 
         if stride == 1:
             self.downsample = None
-        
-        else:    
+
+        else:
             self.downsample = nn.Sequential(
                 nn.Conv2d(in_planes, planes, kernel_size=1, stride=stride), self.norm4)
-
 
     def forward(self, x):
         y = x
@@ -113,7 +110,8 @@ class BottleneckBlock(nn.Module):
         if self.downsample is not None:
             x = self.downsample(x)
 
-        return self.relu(x+y)
+        return self.relu(x + y)
+
 
 class BasicEncoder(nn.Module):
     def __init__(self, output_dim=128, norm_fn='batch', dropout=0.0):
@@ -122,7 +120,7 @@ class BasicEncoder(nn.Module):
 
         if self.norm_fn == 'group':
             self.norm1 = nn.GroupNorm(num_groups=8, num_channels=64)
-            
+
         elif self.norm_fn == 'batch':
             self.norm1 = nn.BatchNorm2d(64)
 
@@ -136,7 +134,7 @@ class BasicEncoder(nn.Module):
         self.relu1 = nn.ReLU(inplace=True)
 
         self.in_planes = 64
-        self.layer1 = self._make_layer(64,  stride=1)
+        self.layer1 = self._make_layer(64, stride=1)
         self.layer2 = self._make_layer(96, stride=2)
         self.layer3 = self._make_layer(128, stride=2)
 
@@ -160,10 +158,9 @@ class BasicEncoder(nn.Module):
         layer1 = ResidualBlock(self.in_planes, dim, self.norm_fn, stride=stride)
         layer2 = ResidualBlock(dim, dim, self.norm_fn, stride=1)
         layers = (layer1, layer2)
-        
+
         self.in_planes = dim
         return nn.Sequential(*layers)
-
 
     def forward(self, x):
 
@@ -199,7 +196,7 @@ class SmallEncoder(nn.Module):
 
         if self.norm_fn == 'group':
             self.norm1 = nn.GroupNorm(num_groups=8, num_channels=32)
-            
+
         elif self.norm_fn == 'batch':
             self.norm1 = nn.BatchNorm2d(32)
 
@@ -213,14 +210,14 @@ class SmallEncoder(nn.Module):
         self.relu1 = nn.ReLU(inplace=True)
 
         self.in_planes = 32
-        self.layer1 = self._make_layer(32,  stride=1)
+        self.layer1 = self._make_layer(32, stride=1)
         self.layer2 = self._make_layer(64, stride=2)
         self.layer3 = self._make_layer(96, stride=2)
 
         self.dropout = None
         if dropout > 0:
             self.dropout = nn.Dropout2d(p=dropout)
-        
+
         self.conv2 = nn.Conv2d(96, output_dim, kernel_size=1)
 
         for m in self.modules():
@@ -236,10 +233,9 @@ class SmallEncoder(nn.Module):
         layer1 = BottleneckBlock(self.in_planes, dim, self.norm_fn, stride=stride)
         layer2 = BottleneckBlock(dim, dim, self.norm_fn, stride=1)
         layers = (layer1, layer2)
-    
+
         self.in_planes = dim
         return nn.Sequential(*layers)
-
 
     def forward(self, x):
 

--- a/models/raft/raft_src/utils/augmentor.py
+++ b/models/raft/raft_src/utils/augmentor.py
@@ -4,6 +4,7 @@ import math
 from PIL import Image
 
 import cv2
+
 cv2.setNumThreads(0)
 cv2.ocl.setUseOpenCL(False)
 
@@ -14,7 +15,7 @@ import torch.nn.functional as F
 
 class FlowAugmentor:
     def __init__(self, crop_size, min_scale=-0.2, max_scale=0.5, do_flip=True):
-        
+
         # spatial augmentation params
         self.crop_size = crop_size
         self.min_scale = min_scale
@@ -29,7 +30,7 @@ class FlowAugmentor:
         self.v_flip_prob = 0.1
 
         # photometric augmentation params
-        self.photo_aug = ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4, hue=0.5/3.14)
+        self.photo_aug = ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4, hue=0.5 / 3.14)
         self.asymmetric_color_aug_prob = 0.2
         self.eraser_aug_prob = 0.5
 
@@ -60,7 +61,7 @@ class FlowAugmentor:
                 y0 = np.random.randint(0, ht)
                 dx = np.random.randint(bounds[0], bounds[1])
                 dy = np.random.randint(bounds[0], bounds[1])
-                img2[y0:y0+dy, x0:x0+dx, :] = mean_color
+                img2[y0:y0 + dy, x0:x0 + dx, :] = mean_color
 
         return img1, img2
 
@@ -68,7 +69,7 @@ class FlowAugmentor:
         # randomly sample scale
         ht, wd = img1.shape[:2]
         min_scale = np.maximum(
-            (self.crop_size[0] + 8) / float(ht), 
+            (self.crop_size[0] + 8) / float(ht),
             (self.crop_size[1] + 8) / float(wd))
 
         scale = 2 ** np.random.uniform(self.min_scale, self.max_scale)
@@ -77,7 +78,7 @@ class FlowAugmentor:
         if np.random.rand() < self.stretch_prob:
             scale_x *= 2 ** np.random.uniform(-self.max_stretch, self.max_stretch)
             scale_y *= 2 ** np.random.uniform(-self.max_stretch, self.max_stretch)
-        
+
         scale_x = np.clip(scale_x, min_scale, None)
         scale_y = np.clip(scale_y, min_scale, None)
 
@@ -89,22 +90,22 @@ class FlowAugmentor:
             flow = flow * [scale_x, scale_y]
 
         if self.do_flip:
-            if np.random.rand() < self.h_flip_prob: # h-flip
+            if np.random.rand() < self.h_flip_prob:  # h-flip
                 img1 = img1[:, ::-1]
                 img2 = img2[:, ::-1]
                 flow = flow[:, ::-1] * [-1.0, 1.0]
 
-            if np.random.rand() < self.v_flip_prob: # v-flip
+            if np.random.rand() < self.v_flip_prob:  # v-flip
                 img1 = img1[::-1, :]
                 img2 = img2[::-1, :]
                 flow = flow[::-1, :] * [1.0, -1.0]
 
         y0 = np.random.randint(0, img1.shape[0] - self.crop_size[0])
         x0 = np.random.randint(0, img1.shape[1] - self.crop_size[1])
-        
-        img1 = img1[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
-        img2 = img2[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
-        flow = flow[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
+
+        img1 = img1[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
+        img2 = img2[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
+        flow = flow[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
 
         return img1, img2, flow
 
@@ -118,6 +119,7 @@ class FlowAugmentor:
         flow = np.ascontiguousarray(flow)
 
         return img1, img2, flow
+
 
 class SparseFlowAugmentor:
     def __init__(self, crop_size, min_scale=-0.2, max_scale=0.5, do_flip=False):
@@ -135,10 +137,10 @@ class SparseFlowAugmentor:
         self.v_flip_prob = 0.1
 
         # photometric augmentation params
-        self.photo_aug = ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.3/3.14)
+        self.photo_aug = ColorJitter(brightness=0.3, contrast=0.3, saturation=0.3, hue=0.3 / 3.14)
         self.asymmetric_color_aug_prob = 0.2
         self.eraser_aug_prob = 0.5
-        
+
     def color_transform(self, img1, img2):
         image_stack = np.concatenate([img1, img2], axis=0)
         image_stack = np.array(self.photo_aug(Image.fromarray(image_stack)), dtype=np.uint8)
@@ -154,7 +156,7 @@ class SparseFlowAugmentor:
                 y0 = np.random.randint(0, ht)
                 dx = np.random.randint(50, 100)
                 dy = np.random.randint(50, 100)
-                img2[y0:y0+dy, x0:x0+dx, :] = mean_color
+                img2[y0:y0 + dy, x0:x0 + dx, :] = mean_color
 
         return img1, img2
 
@@ -167,8 +169,8 @@ class SparseFlowAugmentor:
         flow = flow.reshape(-1, 2).astype(np.float32)
         valid = valid.reshape(-1).astype(np.float32)
 
-        coords0 = coords[valid>=1]
-        flow0 = flow[valid>=1]
+        coords0 = coords[valid >= 1]
+        flow0 = flow[valid >= 1]
 
         ht1 = int(round(ht * fy))
         wd1 = int(round(wd * fx))
@@ -176,8 +178,8 @@ class SparseFlowAugmentor:
         coords1 = coords0 * [fx, fy]
         flow1 = flow0 * [fx, fy]
 
-        xx = np.round(coords1[:,0]).astype(np.int32)
-        yy = np.round(coords1[:,1]).astype(np.int32)
+        xx = np.round(coords1[:, 0]).astype(np.int32)
+        yy = np.round(coords1[:, 1]).astype(np.int32)
 
         v = (xx > 0) & (xx < wd1) & (yy > 0) & (yy < ht1)
         xx = xx[v]
@@ -197,7 +199,7 @@ class SparseFlowAugmentor:
 
         ht, wd = img1.shape[:2]
         min_scale = np.maximum(
-            (self.crop_size[0] + 1) / float(ht), 
+            (self.crop_size[0] + 1) / float(ht),
             (self.crop_size[1] + 1) / float(wd))
 
         scale = 2 ** np.random.uniform(self.min_scale, self.max_scale)
@@ -211,7 +213,7 @@ class SparseFlowAugmentor:
             flow, valid = self.resize_sparse_flow_map(flow, valid, fx=scale_x, fy=scale_y)
 
         if self.do_flip:
-            if np.random.rand() < 0.5: # h-flip
+            if np.random.rand() < 0.5:  # h-flip
                 img1 = img1[:, ::-1]
                 img2 = img2[:, ::-1]
                 flow = flow[:, ::-1] * [-1.0, 1.0]
@@ -226,12 +228,11 @@ class SparseFlowAugmentor:
         y0 = np.clip(y0, 0, img1.shape[0] - self.crop_size[0])
         x0 = np.clip(x0, 0, img1.shape[1] - self.crop_size[1])
 
-        img1 = img1[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
-        img2 = img2[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
-        flow = flow[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
-        valid = valid[y0:y0+self.crop_size[0], x0:x0+self.crop_size[1]]
+        img1 = img1[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
+        img2 = img2[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
+        flow = flow[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
+        valid = valid[y0:y0 + self.crop_size[0], x0:x0 + self.crop_size[1]]
         return img1, img2, flow, valid
-
 
     def __call__(self, img1, img2, flow, valid):
         img1, img2 = self.color_transform(img1, img2)

--- a/models/raft/raft_src/utils/frame_utils.py
+++ b/models/raft/raft_src/utils/frame_utils.py
@@ -4,10 +4,12 @@ from os.path import *
 import re
 
 import cv2
+
 cv2.setNumThreads(0)
 cv2.ocl.setUseOpenCL(False)
 
 TAG_CHAR = np.array([202021.25], np.float32)
+
 
 def readFlow(fn):
     """ Read .flo file in Middlebury format"""
@@ -25,10 +27,11 @@ def readFlow(fn):
             w = np.fromfile(f, np.int32, count=1)
             h = np.fromfile(f, np.int32, count=1)
             # print 'Reading %d x %d flo file\n' % (w, h)
-            data = np.fromfile(f, np.float32, count=2*int(w)*int(h))
+            data = np.fromfile(f, np.float32, count=2 * int(w) * int(h))
             # Reshape data into 3D array (columns, rows, bands)
             # The reshape here is for visualization, the original code is (w,h,2)
             return np.resize(data, (int(h), int(w), 2))
+
 
 def readPFM(file):
     file = open(file, 'rb')
@@ -67,6 +70,7 @@ def readPFM(file):
     data = np.flipud(data)
     return data
 
+
 def writeFlow(filename, uv, v=None):
     """ Write optical flow to file.
 
@@ -77,14 +81,14 @@ def writeFlow(filename, uv, v=None):
     nBands = 2
 
     if v is None:
-        assert(uv.ndim == 3)
-        assert(uv.shape[2] == 2)
+        assert (uv.ndim == 3)
+        assert (uv.shape[2] == 2)
         u = uv[:, :, 0]
         v = uv[:, :, 1]
     else:
         u = uv
 
-    assert(u.shape == v.shape)
+    assert (u.shape == v.shape)
     height, width = u.shape
     f = open(filename, 'wb')
     # write the header
@@ -92,9 +96,9 @@ def writeFlow(filename, uv, v=None):
     np.array(width).astype(np.int32).tofile(f)
     np.array(height).astype(np.int32).tofile(f)
     # arrange into matrix form
-    tmp = np.zeros((height, width*nBands))
-    tmp[:, np.arange(width)*2] = u
-    tmp[:, np.arange(width)*2 + 1] = v
+    tmp = np.zeros((height, width * nBands))
+    tmp[:, np.arange(width) * 2] = u
+    tmp[:, np.arange(width) * 2 + 1] = v
     tmp.astype(np.float32).tofile(f)
     f.close()
 
@@ -103,8 +107,9 @@ def readFlowKITTI(filename):
     flow = cv2.imread(filename, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_COLOR)
     flow = flow[:, :, ::-1].astype(np.float32)
     flow, valid = flow[:, :, :2], flow[:, :, 2]
-    flow = (flow - 2**15) / 64.0
+    flow = (flow - 2 ** 15) / 64.0
     return flow, valid
+
 
 def readDispKITTI(filename):
     disp = cv2.imread(filename, cv2.IMREAD_ANYDEPTH) / 256.0
@@ -114,7 +119,7 @@ def readDispKITTI(filename):
 
 
 def writeFlowKITTI(filename, uv):
-    uv = 64.0 * uv + 2**15
+    uv = 64.0 * uv + 2 ** 15
     valid = np.ones([uv.shape[0], uv.shape[1], 1])
     uv = np.concatenate([uv, valid], axis=-1).astype(np.uint16)
     cv2.imwrite(filename, uv[..., ::-1])

--- a/models/raft/raft_src/utils/utils.py
+++ b/models/raft/raft_src/utils/utils.py
@@ -11,17 +11,18 @@ class InputPadder:
         pad_ht = (((self.ht // 8) + 1) * 8 - self.ht) % 8
         pad_wd = (((self.wd // 8) + 1) * 8 - self.wd) % 8
         if mode == 'sintel':
-            self._pad = [pad_wd//2, pad_wd - pad_wd//2, pad_ht//2, pad_ht - pad_ht//2]
+            self._pad = [pad_wd // 2, pad_wd - pad_wd // 2, pad_ht // 2, pad_ht - pad_ht // 2]
         else:
-            self._pad = [pad_wd//2, pad_wd - pad_wd//2, 0, pad_ht]
+            self._pad = [pad_wd // 2, pad_wd - pad_wd // 2, 0, pad_ht]
 
     def pad(self, *inputs):
         return [F.pad(x, self._pad, mode='replicate') for x in inputs]
 
     def unpad(self, x):
         ht, wd = x.shape[-2:]
-        c = [self._pad[2], ht-self._pad[3], self._pad[0], wd-self._pad[1]]
+        c = [self._pad[2], ht - self._pad[3], self._pad[0], wd - self._pad[1]]
         return x[..., c[0]:c[1], c[2]:c[3]]
+
 
 def forward_interpolate(flow):
     flow = flow.detach().cpu().numpy()
@@ -58,8 +59,8 @@ def bilinear_sampler(img, coords, mode='bilinear', mask=False):
     """ Wrapper for grid_sample, uses pixel coordinates """
     H, W = img.shape[-2:]
     xgrid, ygrid = coords.split([1, 1], dim=-1)
-    xgrid = 2*xgrid/(W-1) - 1
-    ygrid = 2*ygrid/(H-1) - 1
+    xgrid = 2 * xgrid / (W - 1) - 1
+    ygrid = 2 * ygrid / (H - 1) - 1
 
     grid = torch.cat([xgrid, ygrid], dim=-1)
     img = F.grid_sample(img, grid, align_corners=True)

--- a/models/resnet/extract_resnet.py
+++ b/models/resnet/extract_resnet.py
@@ -34,14 +34,14 @@ class ExtractResNet(BaseFrameWiseExtractor):
 
 
     def load_model(self) -> Dict[str, torch.nn.Module]:
-        '''Defines the models, loads checkpoints, sends them to the device.
+        """Defines the models, loads checkpoints, sends them to the device.
 
         Raises:
             NotImplementedError: if a model is not implemented.
 
         Returns:
             Dict[str, torch.nn.Module]: model-agnostic dict holding modules for extraction and show_pred
-        '''
+        """
         try:
             model = getattr(models, self.model_name)
         except AttributeError:

--- a/models/s3d/extract_s3d.py
+++ b/models/s3d/extract_s3d.py
@@ -39,14 +39,14 @@ class ExtractS3D(BaseExtractor):
 
     @torch.no_grad()
     def extract(self, video_path: str) -> Dict[str, np.ndarray]:
-        '''Extracts features for a given video path.
+        """Extracts features for a given video path.
 
         Arguments:
             video_path (str): a video path from which to extract features
 
         Returns:
             Dict[str, np.ndarray]: feature name (e.g. 'fps' or feature_type) to the feature tensor
-        '''
+        """
         # take the video, change fps and save to the tmp folder
         if self.extraction_fps is not None:
             video_path = reencode_video_with_diff_fps(video_path, self.tmp_path, self.extraction_fps)
@@ -54,7 +54,7 @@ class ExtractS3D(BaseExtractor):
         # read a video
         rgb, audio, info = read_video(video_path, pts_unit='sec')
         # prepare data (first -- transform, then -- unsqueeze)
-        rgb = self.transforms(rgb) # could run out of memory here
+        rgb = self.transforms(rgb)  # could run out of memory here
         rgb = rgb.unsqueeze(0)
         # slice the stack of frames
         slices = form_slices(rgb.size(2), self.stack_size, self.step_size)
@@ -75,14 +75,14 @@ class ExtractS3D(BaseExtractor):
         return feats_dict
 
     def load_model(self) -> Dict[str, torch.nn.Module]:
-        '''Defines the models, loads checkpoints, sends them to the device.
+        """Defines the models, loads checkpoints, sends them to the device.
 
         Raises:
             NotImplementedError: if a model is not implemented.
 
         Returns:
             Dict[str, torch.nn.Module]: model-agnostic dict holding modules for extraction and show_pred
-        '''
+        """
         s3d_kinetics400_weights_torch_path = './models/s3d/checkpoint/S3D_kinetics400_torchified.pt'
         model = S3D(num_class=400, ckpt_path=s3d_kinetics400_weights_torch_path)
         model = model.to(self.device)
@@ -91,7 +91,6 @@ class ExtractS3D(BaseExtractor):
         return {
             'model': model,
         }
-
 
     def maybe_show_pred(self, rgb_stack: torch.Tensor, start_idx: int, end_idx: int):
         if self.show_pred:

--- a/models/s3d/s3d_src/s3d.py
+++ b/models/s3d/s3d_src/s3d.py
@@ -1,4 +1,4 @@
-'''adapted from https://github.com/kylemin/S3D'''
+"""adapted from https://github.com/kylemin/S3D"""
 import torch
 from torch import nn
 import torch.nn.functional as F

--- a/models/transforms.py
+++ b/models/transforms.py
@@ -1,12 +1,11 @@
-'''
+"""
 Mostly from torchvision
-'''
+"""
 import torch
 from typing import Iterable
 import numpy as np
 from PIL import Image
 import random
-
 
 
 def crop(vid, i, j, h, w):
@@ -130,7 +129,6 @@ class Pad(object):
         return pad(vid, self.padding, self.fill)
 
 
-
 class TensorCenterCrop(object):
 
     def __init__(self, crop_size: int) -> None:
@@ -190,7 +188,6 @@ class ToFCHW(object):
         return tensor_cfhw.permute(1, 0, 2, 3)
 
 
-
 def resize(img, size, resize_to_smaller_edge=True, interpolation=Image.BILINEAR):
     r"""
     (v-iashin): this is almost the same implementation as in PyTorch except it has no _is_pil_image() check
@@ -233,6 +230,7 @@ def resize(img, size, resize_to_smaller_edge=True, interpolation=Image.BILINEAR)
     else:
         return img.resize(size[::-1], interpolation)
 
+
 class ResizeImproved(object):
 
     def __init__(self, size: int, resize_to_smaller_edge: bool = True, interpolation=Image.BILINEAR):
@@ -243,10 +241,12 @@ class ResizeImproved(object):
     def __call__(self, img):
         return resize(img, self.size, self.resize_to_smaller_edge, self.interpolation)
 
+
 class ToTensorWithoutScaling(object):
 
     def __call__(self, np_img):
         return torch.from_numpy(np_img).permute(2, 0, 1).float()
+
 
 class ToFloat(object):
 
@@ -280,6 +280,7 @@ class PILToTensor:
 
 if __name__ == "__main__":
     import torchvision.transforms as transforms
+
     width = 100
     height = 200
     max_side_size = 512

--- a/models/vggish/extract_vggish.py
+++ b/models/vggish/extract_vggish.py
@@ -29,14 +29,14 @@ class ExtractVGGish(BaseExtractor):
 
     @torch.no_grad()
     def extract(self, video_path: str) -> Dict[str, np.ndarray]:
-        '''Extracts features for a given video path.
+        """Extracts features for a given video path.
 
         Arguments:
             video_path (str): a video path from which to extract features
 
         Returns:
             Dict[str, np.ndarray]: feature name (e.g. 'fps' or feature_type) to the feature tensor
-        '''
+        """
         file_ext = pathlib.Path(video_path).suffix
 
         if file_ext == '.mp4':
@@ -62,12 +62,12 @@ class ExtractVGGish(BaseExtractor):
         return feats_dict
 
     def load_model(self) -> torch.nn.Module:
-        '''Defines the models, loads checkpoints, sends them to the device.
+        """Defines the models, loads checkpoints, sends them to the device.
 
 
         Returns:
             {Dict[str, torch.nn.Module]}: model-agnostic dict holding modules for extraction
-        '''
+        """
         model = VGGish()
         model = model.to(self.device)
         model.eval()

--- a/models/vggish/vggish_src/mel_features.py
+++ b/models/vggish/vggish_src/mel_features.py
@@ -19,7 +19,7 @@ import numpy as np
 
 
 def frame(data, window_length, hop_length):
-  """Convert array into a sequence of successive possibly overlapping frames.
+    """Convert array into a sequence of successive possibly overlapping frames.
 
   An n-dimensional array of shape (num_samples, ...) is converted into an
   (n+1)-D array of shape (num_frames, window_length, ...), where each frame
@@ -38,15 +38,15 @@ def frame(data, window_length, hop_length):
     (N+1)-D np.array with as many rows as there are complete frames that can be
     extracted.
   """
-  num_samples = data.shape[0]
-  num_frames = 1 + int(np.floor((num_samples - window_length) / hop_length))
-  shape = (num_frames, window_length) + data.shape[1:]
-  strides = (data.strides[0] * hop_length,) + data.strides
-  return np.lib.stride_tricks.as_strided(data, shape=shape, strides=strides)
+    num_samples = data.shape[0]
+    num_frames = 1 + int(np.floor((num_samples - window_length) / hop_length))
+    shape = (num_frames, window_length) + data.shape[1:]
+    strides = (data.strides[0] * hop_length,) + data.strides
+    return np.lib.stride_tricks.as_strided(data, shape=shape, strides=strides)
 
 
 def periodic_hann(window_length):
-  """Calculate a "periodic" Hann window.
+    """Calculate a "periodic" Hann window.
 
   The classic Hann window is defined as a raised cosine that starts and
   ends on zero, and where every value appears twice, except the middle
@@ -64,14 +64,14 @@ def periodic_hann(window_length):
   Returns:
     A 1D np.array containing the periodic hann window.
   """
-  return 0.5 - (0.5 * np.cos(2 * np.pi / window_length *
-                             np.arange(window_length)))
+    return 0.5 - (0.5 * np.cos(2 * np.pi / window_length *
+                               np.arange(window_length)))
 
 
 def stft_magnitude(signal, fft_length,
                    hop_length=None,
                    window_length=None):
-  """Calculate the short-time Fourier transform magnitude.
+    """Calculate the short-time Fourier transform magnitude.
 
   Args:
     signal: 1D np.array of the input time-domain signal.
@@ -83,13 +83,13 @@ def stft_magnitude(signal, fft_length,
     2D np.array where each row contains the magnitudes of the fft_length/2+1
     unique values of the FFT for the corresponding frame of input samples.
   """
-  frames = frame(signal, window_length, hop_length)
-  # Apply frame window to each frame. We use a periodic Hann (cosine of period
-  # window_length) instead of the symmetric Hann of np.hanning (period
-  # window_length-1).
-  window = periodic_hann(window_length)
-  windowed_frames = frames * window
-  return np.abs(np.fft.rfft(windowed_frames, int(fft_length)))
+    frames = frame(signal, window_length, hop_length)
+    # Apply frame window to each frame. We use a periodic Hann (cosine of period
+    # window_length) instead of the symmetric Hann of np.hanning (period
+    # window_length-1).
+    window = periodic_hann(window_length)
+    windowed_frames = frames * window
+    return np.abs(np.fft.rfft(windowed_frames, int(fft_length)))
 
 
 # Mel spectrum constants and functions.
@@ -98,7 +98,7 @@ _MEL_HIGH_FREQUENCY_Q = 1127.0
 
 
 def hertz_to_mel(frequencies_hertz):
-  """Convert frequencies to mel scale using HTK formula.
+    """Convert frequencies to mel scale using HTK formula.
 
   Args:
     frequencies_hertz: Scalar or np.array of frequencies in hertz.
@@ -107,8 +107,8 @@ def hertz_to_mel(frequencies_hertz):
     Object of same size as frequencies_hertz containing corresponding values
     on the mel scale.
   """
-  return _MEL_HIGH_FREQUENCY_Q * np.log(
-      1.0 + (frequencies_hertz / _MEL_BREAK_FREQUENCY_HERTZ))
+    return _MEL_HIGH_FREQUENCY_Q * np.log(
+        1.0 + (frequencies_hertz / _MEL_BREAK_FREQUENCY_HERTZ))
 
 
 def spectrogram_to_mel_matrix(num_mel_bins=20,
@@ -116,7 +116,7 @@ def spectrogram_to_mel_matrix(num_mel_bins=20,
                               audio_sample_rate=8000,
                               lower_edge_hertz=125.0,
                               upper_edge_hertz=3800.0):
-  """Return a matrix that can post-multiply spectrogram rows to make mel.
+    """Return a matrix that can post-multiply spectrogram rows to make mel.
 
   Returns a np.array matrix A that can be used to post-multiply a matrix S of
   spectrogram values (STFT magnitudes) arranged as frames x bins to generate a
@@ -152,41 +152,41 @@ def spectrogram_to_mel_matrix(num_mel_bins=20,
   Raises:
     ValueError: if frequency edges are incorrectly ordered or out of range.
   """
-  nyquist_hertz = audio_sample_rate / 2.
-  if lower_edge_hertz < 0.0:
-    raise ValueError("lower_edge_hertz %.1f must be >= 0" % lower_edge_hertz)
-  if lower_edge_hertz >= upper_edge_hertz:
-    raise ValueError("lower_edge_hertz %.1f >= upper_edge_hertz %.1f" %
-                     (lower_edge_hertz, upper_edge_hertz))
-  if upper_edge_hertz > nyquist_hertz:
-    raise ValueError("upper_edge_hertz %.1f is greater than Nyquist %.1f" %
-                     (upper_edge_hertz, nyquist_hertz))
-  spectrogram_bins_hertz = np.linspace(0.0, nyquist_hertz, num_spectrogram_bins)
-  spectrogram_bins_mel = hertz_to_mel(spectrogram_bins_hertz)
-  # The i'th mel band (starting from i=1) has center frequency
-  # band_edges_mel[i], lower edge band_edges_mel[i-1], and higher edge
-  # band_edges_mel[i+1].  Thus, we need num_mel_bins + 2 values in
-  # the band_edges_mel arrays.
-  band_edges_mel = np.linspace(hertz_to_mel(lower_edge_hertz),
-                               hertz_to_mel(upper_edge_hertz), num_mel_bins + 2)
-  # Matrix to post-multiply feature arrays whose rows are num_spectrogram_bins
-  # of spectrogram values.
-  mel_weights_matrix = np.empty((num_spectrogram_bins, num_mel_bins))
-  for i in range(num_mel_bins):
-    lower_edge_mel, center_mel, upper_edge_mel = band_edges_mel[i:i + 3]
-    # Calculate lower and upper slopes for every spectrogram bin.
-    # Line segments are linear in the *mel* domain, not hertz.
-    lower_slope = ((spectrogram_bins_mel - lower_edge_mel) /
-                   (center_mel - lower_edge_mel))
-    upper_slope = ((upper_edge_mel - spectrogram_bins_mel) /
-                   (upper_edge_mel - center_mel))
-    # .. then intersect them with each other and zero.
-    mel_weights_matrix[:, i] = np.maximum(0.0, np.minimum(lower_slope,
-                                                          upper_slope))
-  # HTK excludes the spectrogram DC bin; make sure it always gets a zero
-  # coefficient.
-  mel_weights_matrix[0, :] = 0.0
-  return mel_weights_matrix
+    nyquist_hertz = audio_sample_rate / 2.
+    if lower_edge_hertz < 0.0:
+        raise ValueError("lower_edge_hertz %.1f must be >= 0" % lower_edge_hertz)
+    if lower_edge_hertz >= upper_edge_hertz:
+        raise ValueError("lower_edge_hertz %.1f >= upper_edge_hertz %.1f" %
+                         (lower_edge_hertz, upper_edge_hertz))
+    if upper_edge_hertz > nyquist_hertz:
+        raise ValueError("upper_edge_hertz %.1f is greater than Nyquist %.1f" %
+                         (upper_edge_hertz, nyquist_hertz))
+    spectrogram_bins_hertz = np.linspace(0.0, nyquist_hertz, num_spectrogram_bins)
+    spectrogram_bins_mel = hertz_to_mel(spectrogram_bins_hertz)
+    # The i'th mel band (starting from i=1) has center frequency
+    # band_edges_mel[i], lower edge band_edges_mel[i-1], and higher edge
+    # band_edges_mel[i+1].  Thus, we need num_mel_bins + 2 values in
+    # the band_edges_mel arrays.
+    band_edges_mel = np.linspace(hertz_to_mel(lower_edge_hertz),
+                                 hertz_to_mel(upper_edge_hertz), num_mel_bins + 2)
+    # Matrix to post-multiply feature arrays whose rows are num_spectrogram_bins
+    # of spectrogram values.
+    mel_weights_matrix = np.empty((num_spectrogram_bins, num_mel_bins))
+    for i in range(num_mel_bins):
+        lower_edge_mel, center_mel, upper_edge_mel = band_edges_mel[i:i + 3]
+        # Calculate lower and upper slopes for every spectrogram bin.
+        # Line segments are linear in the *mel* domain, not hertz.
+        lower_slope = ((spectrogram_bins_mel - lower_edge_mel) /
+                       (center_mel - lower_edge_mel))
+        upper_slope = ((upper_edge_mel - spectrogram_bins_mel) /
+                       (upper_edge_mel - center_mel))
+        # .. then intersect them with each other and zero.
+        mel_weights_matrix[:, i] = np.maximum(0.0, np.minimum(lower_slope,
+                                                              upper_slope))
+    # HTK excludes the spectrogram DC bin; make sure it always gets a zero
+    # coefficient.
+    mel_weights_matrix[0, :] = 0.0
+    return mel_weights_matrix
 
 
 def log_mel_spectrogram(data,
@@ -195,7 +195,7 @@ def log_mel_spectrogram(data,
                         window_length_secs=0.025,
                         hop_length_secs=0.010,
                         **kwargs):
-  """Convert waveform to a log magnitude mel-frequency spectrogram.
+    """Convert waveform to a log magnitude mel-frequency spectrogram.
 
   Args:
     data: 1D np.array of waveform data.
@@ -209,15 +209,15 @@ def log_mel_spectrogram(data,
     2D np.array of (num_frames, num_mel_bins) consisting of log mel filterbank
     magnitudes for successive frames.
   """
-  window_length_samples = int(round(audio_sample_rate * window_length_secs))
-  hop_length_samples = int(round(audio_sample_rate * hop_length_secs))
-  fft_length = 2 ** int(np.ceil(np.log(window_length_samples) / np.log(2.0)))
-  spectrogram = stft_magnitude(
-      data,
-      fft_length=fft_length,
-      hop_length=hop_length_samples,
-      window_length=window_length_samples)
-  mel_spectrogram = np.dot(spectrogram, spectrogram_to_mel_matrix(
-      num_spectrogram_bins=spectrogram.shape[1],
-      audio_sample_rate=audio_sample_rate, **kwargs))
-  return np.log(mel_spectrogram + log_offset)
+    window_length_samples = int(round(audio_sample_rate * window_length_secs))
+    hop_length_samples = int(round(audio_sample_rate * hop_length_secs))
+    fft_length = 2 ** int(np.ceil(np.log(window_length_samples) / np.log(2.0)))
+    spectrogram = stft_magnitude(
+        data,
+        fft_length=fft_length,
+        hop_length=hop_length_samples,
+        window_length=window_length_samples)
+    mel_spectrogram = np.dot(spectrogram, spectrogram_to_mel_matrix(
+        num_spectrogram_bins=spectrogram.shape[1],
+        audio_sample_rate=audio_sample_rate, **kwargs))
+    return np.log(mel_spectrogram + log_offset)

--- a/models/vggish/vggish_src/vggish_postprocess.py
+++ b/models/vggish/vggish_src/vggish_postprocess.py
@@ -20,7 +20,7 @@ from models.vggish.vggish_src import vggish_params
 
 
 class Postprocessor(object):
-  """Post-processes VGGish embeddings.
+    """Post-processes VGGish embeddings.
 
   The initial release of AudioSet included 128-D VGGish embeddings for each
   segment of AudioSet. These released embeddings were produced by applying
@@ -31,25 +31,25 @@ class Postprocessor(object):
   the same PCA (with whitening) and quantization transformations.
   """
 
-  def __init__(self, pca_params_npz_path):
-    """Constructs a postprocessor.
+    def __init__(self, pca_params_npz_path):
+        """Constructs a postprocessor.
 
     Args:
       pca_params_npz_path: Path to a NumPy-format .npz file that
         contains the PCA parameters used in postprocessing.
     """
-    params = np.load(pca_params_npz_path)
-    self._pca_matrix = params[vggish_params.PCA_EIGEN_VECTORS_NAME]
-    # Load means into a column vector for easier broadcasting later.
-    self._pca_means = params[vggish_params.PCA_MEANS_NAME].reshape(-1, 1)
-    assert self._pca_matrix.shape == (
-        vggish_params.EMBEDDING_SIZE, vggish_params.EMBEDDING_SIZE), (
-            'Bad PCA matrix shape: %r' % (self._pca_matrix.shape,))
-    assert self._pca_means.shape == (vggish_params.EMBEDDING_SIZE, 1), (
-        'Bad PCA means shape: %r' % (self._pca_means.shape,))
+        params = np.load(pca_params_npz_path)
+        self._pca_matrix = params[vggish_params.PCA_EIGEN_VECTORS_NAME]
+        # Load means into a column vector for easier broadcasting later.
+        self._pca_means = params[vggish_params.PCA_MEANS_NAME].reshape(-1, 1)
+        assert self._pca_matrix.shape == (
+            vggish_params.EMBEDDING_SIZE, vggish_params.EMBEDDING_SIZE), (
+                'Bad PCA matrix shape: %r' % (self._pca_matrix.shape,))
+        assert self._pca_means.shape == (vggish_params.EMBEDDING_SIZE, 1), (
+                'Bad PCA means shape: %r' % (self._pca_means.shape,))
 
-  def postprocess(self, embeddings_batch):
-    """Applies postprocessing to a batch of embeddings.
+    def postprocess(self, embeddings_batch):
+        """Applies postprocessing to a batch of embeddings.
 
     Args:
       embeddings_batch: An nparray of shape [batch_size, embedding_size]
@@ -59,32 +59,32 @@ class Postprocessor(object):
       An nparray of the same shape as the input but of type uint8,
       containing the PCA-transformed and quantized version of the input.
     """
-    assert len(embeddings_batch.shape) == 2, (
-        'Expected 2-d batch, got %r' % (embeddings_batch.shape,))
-    assert embeddings_batch.shape[1] == vggish_params.EMBEDDING_SIZE, (
-        'Bad batch shape: %r' % (embeddings_batch.shape,))
+        assert len(embeddings_batch.shape) == 2, (
+                'Expected 2-d batch, got %r' % (embeddings_batch.shape,))
+        assert embeddings_batch.shape[1] == vggish_params.EMBEDDING_SIZE, (
+                'Bad batch shape: %r' % (embeddings_batch.shape,))
 
-    # Apply PCA.
-    # - Embeddings come in as [batch_size, embedding_size].
-    # - Transpose to [embedding_size, batch_size].
-    # - Subtract pca_means column vector from each column.
-    # - Premultiply by PCA matrix of shape [output_dims, input_dims]
-    #   where both are are equal to embedding_size in our case.
-    # - Transpose result back to [batch_size, embedding_size].
-    pca_applied = np.dot(self._pca_matrix,
-                         (embeddings_batch.T - self._pca_means)).T
+        # Apply PCA.
+        # - Embeddings come in as [batch_size, embedding_size].
+        # - Transpose to [embedding_size, batch_size].
+        # - Subtract pca_means column vector from each column.
+        # - Premultiply by PCA matrix of shape [output_dims, input_dims]
+        #   where both are are equal to embedding_size in our case.
+        # - Transpose result back to [batch_size, embedding_size].
+        pca_applied = np.dot(self._pca_matrix,
+                             (embeddings_batch.T - self._pca_means)).T
 
-    # Quantize by:
-    # - clipping to [min, max] range
-    clipped_embeddings = np.clip(
-        pca_applied, vggish_params.QUANTIZE_MIN_VAL,
-        vggish_params.QUANTIZE_MAX_VAL)
-    # - convert to 8-bit in range [0.0, 255.0]
-    quantized_embeddings = (
-        (clipped_embeddings - vggish_params.QUANTIZE_MIN_VAL) *
-        (255.0 /
-         (vggish_params.QUANTIZE_MAX_VAL - vggish_params.QUANTIZE_MIN_VAL)))
-    # - cast 8-bit float to uint8
-    quantized_embeddings = quantized_embeddings.astype(np.uint8)
+        # Quantize by:
+        # - clipping to [min, max] range
+        clipped_embeddings = np.clip(
+            pca_applied, vggish_params.QUANTIZE_MIN_VAL,
+            vggish_params.QUANTIZE_MAX_VAL)
+        # - convert to 8-bit in range [0.0, 255.0]
+        quantized_embeddings = (
+                (clipped_embeddings - vggish_params.QUANTIZE_MIN_VAL) *
+                (255.0 /
+                 (vggish_params.QUANTIZE_MAX_VAL - vggish_params.QUANTIZE_MIN_VAL)))
+        # - cast 8-bit float to uint8
+        quantized_embeddings = quantized_embeddings.astype(np.uint8)
 
-    return quantized_embeddings
+        return quantized_embeddings

--- a/tests/clip/test_clip.py
+++ b/tests/clip/test_clip.py
@@ -29,6 +29,7 @@ test_params = [
     # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'RN50', 1, None, TO_MAKE_REF),
 ]
 
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, model_name, batch_size, extraction_fps, to_make_ref):
     # get config

--- a/tests/i3d/test_i3d.py
+++ b/tests/i3d/test_i3d.py
@@ -35,6 +35,7 @@ else:
         ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'flow', 'raft', None, None, None, TO_MAKE_REF),
     ]
 
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, streams, flow_type, stack_size, step_size, extraction_fps, to_make_ref):
     # get config

--- a/tests/pwc/test_pwc.py
+++ b/tests/pwc/test_pwc.py
@@ -1,7 +1,7 @@
-'''
+"""
     The content of this file is commented to avoid parsing it with pytest test discovery.
     Since PWC optical flow extraction depends on another env
-'''
+"""
 import sys
 from pathlib import Path
 
@@ -18,7 +18,6 @@ from tests.utils import base_test_script
 THIS_FILE_PATH = __file__
 FEATURE_TYPE = Path(THIS_FILE_PATH).parent.name
 
-
 # True when run for the first time, then must be False
 TO_MAKE_REF = False
 
@@ -28,6 +27,7 @@ test_params = [
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 112, 3, TO_MAKE_REF),  # 18M
     # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 384, 5, TO_MAKE_REF),  # 345M
 ]
+
 
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, side_size, extraction_fps, to_make_ref):

--- a/tests/r21d/test_r21d.py
+++ b/tests/r21d/test_r21d.py
@@ -14,7 +14,6 @@ from tests.utils import base_test_script
 THIS_FILE_PATH = __file__
 FEATURE_TYPE = Path(THIS_FILE_PATH).parent.name
 
-
 # True when run for the first time, then must be False
 TO_MAKE_REF = False
 
@@ -25,6 +24,8 @@ test_params = [
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, None, TO_MAKE_REF),
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'r2plus1d_34_8_ig65m_ft_kinetics', None, None, 1, TO_MAKE_REF),
 ]
+
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, model_name, stack_size, step_size, extraction_fps, to_make_ref):
     # get config

--- a/tests/raft/test_raft.py
+++ b/tests/raft/test_raft.py
@@ -14,7 +14,6 @@ from tests.utils import base_test_script
 THIS_FILE_PATH = __file__
 FEATURE_TYPE = Path(THIS_FILE_PATH).parent.name
 
-
 # True when run for the first time, then must be False
 TO_MAKE_REF = False
 
@@ -24,11 +23,13 @@ test_params = [
     # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, None, True, None, TO_MAKE_REF), # 500MB+
     # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, None, True, None, TO_MAKE_REF), # 500MB+
     # ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, None, TO_MAKE_REF), # 500MB+
-    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, None, True, 1, TO_MAKE_REF), # 26M
-    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, 256, True, 1, TO_MAKE_REF), # 26M
-    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, 256, False, 1, TO_MAKE_REF), # 17M
-    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, 1, TO_MAKE_REF), # 17M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, None, True, 1, TO_MAKE_REF),  # 26M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'kitti', 1, 256, True, 1, TO_MAKE_REF),  # 26M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 16, 256, False, 1, TO_MAKE_REF),  # 17M
+    ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'sintel', 1, 256, False, 1, TO_MAKE_REF),  # 17M
 ]
+
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, finetuned_on, batch_size, side_size, resize_to_smaller_edge, extraction_fps, to_make_ref):
     # get config

--- a/tests/resnet/test_resnet.py
+++ b/tests/resnet/test_resnet.py
@@ -14,10 +14,8 @@ from tests.utils import base_test_script
 THIS_FILE_PATH = __file__
 FEATURE_TYPE = Path(THIS_FILE_PATH).parent.name
 
-
 # True when run for the first time, then must be False
 TO_MAKE_REF = False
-
 
 signature = 'device, video_paths, model_name, batch_size, extraction_fps, to_make_ref'
 test_params = [
@@ -25,6 +23,8 @@ test_params = [
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'resnet50', 1, None, TO_MAKE_REF),
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 'resnet34', 64, None, TO_MAKE_REF),
 ]
+
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, model_name, batch_size, extraction_fps, to_make_ref):
     # get config

--- a/tests/s3d/test_s3d.py
+++ b/tests/s3d/test_s3d.py
@@ -14,7 +14,6 @@ from tests.utils import base_test_script
 THIS_FILE_PATH = __file__
 FEATURE_TYPE = Path(THIS_FILE_PATH).parent.name
 
-
 # True when run for the first time, then must be False
 TO_MAKE_REF = False
 
@@ -23,6 +22,8 @@ test_params = [
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', None, None, None, TO_MAKE_REF),
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', 32, 32, 20, TO_MAKE_REF),
 ]
+
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, stack_size, step_size, extraction_fps, to_make_ref):
     # get config

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,7 @@ def md5sum(path: str):
         content = f.read()
     return hashlib.md5(content).hexdigest()
 
+
 def make_ref_path(feature_type, file_key, **patch_kwargs):
     filename = ''
     for k, v in patch_kwargs.items():
@@ -31,6 +32,7 @@ def make_ref_path(feature_type, file_key, **patch_kwargs):
     ref_path = Path('./tests') / feature_type / 'reference' / filename
     return ref_path
 
+
 def make_ref(args, video_path: Path, data, save_path):
     assert not save_path.exists()
     save_path.parent.mkdir(exist_ok=True)
@@ -43,12 +45,14 @@ def make_ref(args, video_path: Path, data, save_path):
     torch.save(to_save, save_path)
     print('Saved to', save_path)
 
+
 def get_config(feature_type, **patch_kwargs):
     config = OmegaConf.load(build_cfg_path(feature_type))
     for k, v in patch_kwargs.items():
         setattr(config, k, v)
     sanity_check(config)
     return config
+
 
 def get_import_api_feats(extractor, video_paths):
     feat_out_import = extractor.extract(video_paths)
@@ -84,16 +88,19 @@ def get_cmd_api_feats(feature_type: str, file_keys: List[str], **patch_kwargs):
 
             # read from the saved file
             for key in file_keys:
-                load_path = Path(make_path(output_root_load, patch_kwargs['video_paths'], key, action2ext[on_extraction]))
+                load_path = Path(
+                    make_path(output_root_load, patch_kwargs['video_paths'], key, action2ext[on_extraction]))
                 assert load_path.exists(), (load_path, output_root_load)
                 feat_out_cmd[on_extraction][key] = action2loadfn[on_extraction](str(load_path))
 
     return feat_out_cmd
 
+
 # TODO: replace it with numpy's or torch's all close
 def all_close(a, b, tol=1e-6) -> bool:
     '''Determines if tensors/values `a` and `b` are close to each other given a tolerance'''
     return abs(a - b).sum() < tol
+
 
 def base_test_script(feature_type: str, Extractor, to_make_ref: bool, **patch_kwargs):
     args = get_config(feature_type, **patch_kwargs)

--- a/tests/vggish/test_vggish.py
+++ b/tests/vggish/test_vggish.py
@@ -14,7 +14,6 @@ from tests.utils import base_test_script
 THIS_FILE_PATH = __file__
 FEATURE_TYPE = Path(THIS_FILE_PATH).parent.name
 
-
 # True when run for the first time, then must be False
 TO_MAKE_REF = False
 
@@ -22,6 +21,8 @@ signature = 'device, video_paths, to_make_ref'
 test_params = [
     ('cuda:0', './sample/v_GGSY1Qvo990.mp4', TO_MAKE_REF),
 ]
+
+
 @pytest.mark.parametrize(signature, test_params)
 def test(device, video_paths, to_make_ref):
     # get config

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -18,12 +18,12 @@ KINETICS_CLASS_PATH = './utils/K400_label_map.txt'
 
 
 def show_predictions_on_dataset(logits: torch.FloatTensor, dataset: Union[str, List]):
-    '''Prints out predictions for each feature
+    """Prints out predictions for each feature
 
     Args:
         logits (torch.FloatTensor): after-classification layer vector (B, classes)
         dataset (str): which dataset to use to show the predictions on. In ('imagenet', 'kinetics')
-    '''
+    """
     if dataset == 'kinetics':
         dataset_classes = [x.strip() for x in open(KINETICS_CLASS_PATH)]
     elif dataset == 'imagenet':
@@ -50,14 +50,16 @@ def show_predictions_on_dataset(logits: torch.FloatTensor, dataset: Union[str, L
             print(f'{logit:8.3f} | {smax:.3f} | {cls}')
         print()
 
+
 def make_path(output_root, video_path, output_key, ext):
     # extract file name and change the extention
     fname = f'{Path(video_path).stem}_{output_key}{ext}'
     # construct the paths to save the features
     return os.path.join(output_root, fname)
 
+
 def form_slices(size: int, stack_size: int, step_size: int) -> list((int, int)):
-    '''print(form_slices(100, 15, 15) - example'''
+    """print(form_slices(100, 15, 15) - example"""
     slices = []
     # calc how many full stacks can be formed out of framepaths
     full_stack_num = (size - stack_size) // step_size + 1
@@ -69,11 +71,11 @@ def form_slices(size: int, stack_size: int, step_size: int) -> list((int, int)):
 
 
 def sanity_check(args: Union[argparse.Namespace, DictConfig]):
-    '''Checks user arguments.
+    """Checks user arguments.
 
     Args:
         args (Union[argparse.Namespace, DictConfig]): Parsed user arguments
-    '''
+    """
     if 'device_ids' in args:
         print('WARNING:')
         print('Running feature extraction on multiple devices in a _single_ process is no longer supported.')
@@ -126,8 +128,8 @@ def form_list_from_user_input(
         video_paths: Union[str, ListConfig, None] = None,
         file_with_video_paths: str = None,
         to_shuffle: bool = True,
-    ) -> list:
-    '''User specifies either list of videos in the cmd or a path to a file with video paths. This function
+) -> list:
+    """User specifies either list of videos in the cmd or a path to a file with video paths. This function
        transforms the user input into a list of paths.
 
     Args:
@@ -139,7 +141,7 @@ def form_list_from_user_input(
 
     Returns:
         list: list with paths
-    '''
+    """
     if file_with_video_paths is None:
         path_list = [video_paths] if isinstance(video_paths, str) else list(video_paths)
         # TODO: the following `if` could be redundant
@@ -165,11 +167,11 @@ def form_list_from_user_input(
 
 
 def which_ffmpeg() -> str:
-    '''Determines the path to ffmpeg library
+    """Determines the path to ffmpeg library
 
     Returns:
         str -- path to the library
-    '''
+    """
     # Determine the platform on which the program is running
     if platform.system().lower() == 'windows':
         result = subprocess.run(['where', 'ffmpeg'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -181,7 +183,7 @@ def which_ffmpeg() -> str:
 
 
 def reencode_video_with_diff_fps(video_path: str, tmp_path: str, extraction_fps: float) -> str:
-    '''Reencodes the video given the path and saves it to the tmp_path folder.
+    """Reencodes the video given the path and saves it to the tmp_path folder.
 
     Args:
         video_path (str): original video
@@ -190,7 +192,7 @@ def reencode_video_with_diff_fps(video_path: str, tmp_path: str, extraction_fps:
 
     Returns:
         str: The path where the tmp file is stored. To be used to load the video from
-    '''
+    """
     assert which_ffmpeg() != '', 'Is ffmpeg installed? Check if the conda environment is activated.'
     assert video_path.endswith('.mp4'), 'The file does not end with .mp4. Comment this if expected'
     # create tmp dir if doesn't exist
@@ -206,7 +208,7 @@ def reencode_video_with_diff_fps(video_path: str, tmp_path: str, extraction_fps:
 
 
 def extract_wav_from_mp4(video_path: str, tmp_path: str) -> str:
-    '''Extracts .wav file from .aac which is extracted from .mp4
+    """Extracts .wav file from .aac which is extracted from .mp4
     We cannot convert .mp4 to .wav directly. For this we do it in two stages: .mp4 -> .aac -> .wav
 
     Args:
@@ -215,7 +217,7 @@ def extract_wav_from_mp4(video_path: str, tmp_path: str) -> str:
 
     Returns:
         [str, str] -- path to the .wav and .aac audio
-    '''
+    """
     assert which_ffmpeg() != '', 'Is ffmpeg installed? Check if the conda environment is activated.'
     assert video_path.endswith('.mp4'), 'The file does not end with .mp4. Comment this if expected'
     # create tmp dir if doesn't exist
@@ -238,21 +240,21 @@ def extract_wav_from_mp4(video_path: str, tmp_path: str) -> str:
 
 
 def build_cfg_path(feature_type: str) -> os.PathLike:
-    '''Makes a path to the default config file for each feature family.
+    """Makes a path to the default config file for each feature family.
 
     Args:
         feature_type (str): the type (e.g. 'vggish')
 
     Returns:
         os.PathLike: the path to the default config for the type
-    '''
+    """
     path_base = Path('./configs')
     path = path_base / f'{feature_type}.yml'
     return path
 
 
 def dp_state_to_normal(state_dict):
-    '''Converts a torch.DataParallel checkpoint to regular'''
+    """Converts a torch.DataParallel checkpoint to regular"""
     new_state_dict = {}
     for k, v in state_dict.items():
         if k.startswith('module'):
@@ -263,11 +265,14 @@ def dp_state_to_normal(state_dict):
 def load_numpy(fpath):
     return np.load(fpath)
 
+
 def write_numpy(fpath, value):
     return np.save(fpath, value)
 
+
 def load_pickle(fpath):
     return pickle.load(open(fpath, 'rb'))
+
 
 def write_pickle(fpath, value):
     return pickle.dump(value, open(fpath, 'wb'))


### PR DESCRIPTION
- PEP 257: Triple double-quoted strings should be used for docstrings. #74
- PEP 8: E111 indentation is not a multiple of 4
- PEP 8: E231 missing whitespace after ','
- PEP 8: E303 too many blank lines (2)
- PEP 8: E501 line too long (186 > 120 characters)
- PEP 8: E128 continuation line under-indented for visual indent