### PR TITLE
ci: update actions/checkout to v4 and setup-python to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mdx_truly_sane_lists


### PR DESCRIPTION
## Summary

Update the following GitHub Actions versions:

- `actions/checkout` from `v2` to `v4`
- `actions/setup-python` from `v2` to `v5`

## Reason for Update

The current CI setup relies on actions that depend on Node.js 12, which has reached its end of life (EOL). This update aligns the actions with Node.js 20 compatibility, resolving deprecation warnings.

![image](https://github.com/user-attachments/assets/9cac4035-1eaf-4589-956f-465929e7cfd9)

https://github.com/v-iashin/video_features/actions/runs/10826776862

## Additional Information

- [GitHub Actions: All Actions will begin running on Node16 instead of Node12 - GitHub blog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
-  [GitHub Actions: Transitioning from Node 16 to Node 20 - GitHub blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
