### PR TITLE
docs: consolidate setup instructions into a single page

### DIFF
--- a/docs/meta/install_conda.md
+++ b/docs/meta/install_conda.md
@@ -1,4 +1,18 @@
+# Setup Environment
+
+## Using the YAML File
+
+If you want to quickly set up the `conda` environment with all the required dependencies, use the `conda_env.yml` file. Run the following command:
+
+```bash
+# it will create a new conda environment called 'video_features' on your machine
+conda env create -f conda_env.yml
+```
+
+## From Scratch
+
 Just steps to install conda and create a new environment from scratch.
+
 ```bash
 conda create -n video_features
 conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia

--- a/docs/models/clip.md
+++ b/docs/models/clip.md
@@ -13,19 +13,11 @@ We additionally output timesteps in ms for each feature and fps of the video.
 
 ---
 
-## Set up the Environment for CLIP
-Setup `conda` environment. Requirements are in file `conda_env.yml`
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
----
-
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1Zd7r8uKGLGSxlil4PPnXk_4I3KOsjPpO?usp=sharing)
 
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash
@@ -65,6 +57,9 @@ python main.py \
 ---
 
 ## Examples
+
+Make sure the environment is set up correctly. For instructions, refer to [Setup Environment](../meta/install_conda.md).
+
 Start by activating the environment
 ```bash
 conda activate video_features

--- a/docs/models/i3d.md
+++ b/docs/models/i3d.md
@@ -43,18 +43,11 @@ You may check if the predicted distribution satisfies your requirements for an a
 
 ---
 
-## Set up the Environment for I3D
-Check if you have a correct conda environment installed
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
----
-
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1LKoytZmNxtC-EuCp7pHDM6sFvK1XdwlW?usp=sharing)
+
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash
@@ -73,6 +66,9 @@ python main.py \
 ---
 
 ## Examples
+
+Make sure the environment is set up correctly. For instructions, refer to [Setup Environment](../meta/install_conda.md).
+
 Activate the environment
 ```bash
 conda activate video_features

--- a/docs/models/r21d.md
+++ b/docs/models/r21d.md
@@ -29,21 +29,13 @@ which spans 0.64 seconds of the video recorded at 25 fps.
 In the default case, the features will be of size `Tv x 512` where `Tv = duration / 0.64`.
 Specify, `model_name`, `step_size` and `stack_size` to change the default behavior.
 
-
----
-
-## Set up the Environment for R(2+1)D
-Setup `conda` environment. Requirements are in file `conda_env.yml`
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
 ---
 
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1csJgkVQ3E2qOyVlcOM-ACHGgPBBKwE2Y?usp=sharing)
+
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash
@@ -81,6 +73,9 @@ python main.py \
 ---
 
 ## Example
+
+Make sure the environment is set up correctly. For instructions, refer to [Setup Environment](../meta/install_conda.md).
+
 Start by activating the environment
 ```bash
 conda activate video_features

--- a/docs/models/raft.md
+++ b/docs/models/raft.md
@@ -16,18 +16,11 @@ The optical flow frames have the same size as the video input or as specified by
 
 ---
 
-## Set up the Environment for RAFT
-Setup `conda` environment. Requirements for RAFT are similar to the torchvision zoo, which uses `conda_env.yml`
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
----
-
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/18I95Rn1B3a2ISfD9b-o4o93m3XuHbcIY?usp=sharing)
+
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash
@@ -68,6 +61,8 @@ To use `show_pred=true`, a screen must be attached to the machine or X11 forward
 ---
 
 ## Examples
+
+Make sure the environment is set up correctly. For instructions, refer to [Setup Environment](../meta/install_conda.md).
 
 Start by activating the environment
 ```bash

--- a/docs/models/resnet.md
+++ b/docs/models/resnet.md
@@ -13,18 +13,11 @@ We additionally output timesteps in ms for each feature and fps of the video. We
 
 ---
 
-## Set up the Environment for ResNet
-Setup `conda` environment. Requirements are in file `conda_env.yml`
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
----
-
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/17VLdf4abQT2eoMjc6ziJ9UaRaOklTlP0?usp=sharing)
+
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash
@@ -63,6 +56,9 @@ python main.py \
 ---
 
 ## Examples
+
+Make sure the environment is set up correctly. For instructions, refer to [Setup Environment](../meta/install_conda.md).
+
 Start by activating the environment
 ```bash
 conda activate video_features

--- a/docs/models/s3d.md
+++ b/docs/models/s3d.md
@@ -26,21 +26,13 @@ What is extracted exactly?
 The inputs to the classification head (see `S3D.fc` and `S3D.forward`) that were average-pooled
 across the time dimension.
 
-
----
-
-## Set up the Environment for S3D
-Setup `conda` environment. Requirements are in file `conda_env.yml`
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
 ---
 
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1HUlYcOJf_dArOcAaR9jaQHuM5CAZiNZc?usp=sharing)
+
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash

--- a/docs/models/vggish.md
+++ b/docs/models/vggish.md
@@ -12,18 +12,11 @@ The extraction of VGGish features is implemeted as a wrapper of the TensorFlow i
 
 ---
 
-## Set up the Environment for VGGish
-Setup `conda` environment. Requirements are in file `conda_env.yml`
-```bash
-# it will create a new conda environment called 'video_features' on your machine
-conda env create -f conda_env.yml
-```
-
----
-
 ## Quick Start
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1r_8OnmwXKwmH0n4RxBfuICVBgpbJt_Fs?usp=sharing)
+
+Ensure that the environment is properly set up before proceeding. See [Setup Environment](../meta/install_conda.md) for detailed instructions.
 
 Activate the environment
 ```bash
@@ -55,6 +48,14 @@ python main.py \
 ---
 
 ## Example
+
+Make sure the environment is set up correctly. For instructions, refer to [Setup Environment](../meta/install_conda.md).
+
+Activate the environment
+
+```bash
+conda activate video_features
+```
 
 The video paths can be specified as a `.txt` file with paths.
 ```bash


### PR DESCRIPTION
This PR resolves redundancy in the documentation by consolidating environment setup instructions into a single "Setup Environment" page.

## Changes

- `meta/install_conda.md`
  - add YAML-based setup instructions
- Update individual model pages to reference the new page instead of duplicating the instructions.
## Resolves

Closes #119 