### PR TITLE
docs: enable syntax highlighting and copy button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,10 @@ markdown_extensions:
   - admonition
   - mdx_truly_sane_lists
   - tables
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ theme:
   name: material
   palette:
     primary: red
+  features:
+    - content.code.copy
 repo_url: https://github.com/v-iashin/video_features
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Syntax highlighting is incomplete, but should be a bit easier to read. 🤔

Before:

<img src="https://github.com/user-attachments/assets/2a72ff23-1d91-48c3-b096-a31ac2582f1b" width="70%">

<img src="https://github.com/user-attachments/assets/3a097ed4-7e5f-49f8-a552-7840cee4fb43" width="70%">

After:

<img src="https://github.com/user-attachments/assets/74740ecd-4335-4fc3-a84a-102457eaaeb1" width="70%">

<img src="https://github.com/user-attachments/assets/c3647659-cc79-4f33-b7a8-6969056ffb96" width="70%">

## Reference
[Code Blocks - Material for MKDocs](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/)